### PR TITLE
🔖 Release version 1.4.0

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,4 +1,5 @@
 {
   "arrowParens": "avoid",
-  "endOfLine": "auto"
+  "endOfLine": "auto",
+  "order": "smacss"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@types/webextension-polyfill": "^0.9.1",
         "parcel": "^2.8.0",
         "prettier": "^2.8.0",
-        "prettier-plugin-organize-imports": "^3.2.0",
+        "prettier-plugin-organize-imports": "^3.2.1",
         "typescript": "^4.9.3",
         "webextension-polyfill": "^0.10.0"
       }
@@ -2553,9 +2553,9 @@
       }
     },
     "node_modules/prettier-plugin-organize-imports": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-3.2.0.tgz",
-      "integrity": "sha512-jeZ13YVKgXYCzkuwnoR6saKxJmdRYWMxS2G/su1V3qDWqTo1Q5iSoTblBxsXXAmomXfPqa/uA7YCK0/S86KLOQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-3.2.1.tgz",
+      "integrity": "sha512-bty7C2Ecard5EOXirtzeCAqj4FU4epeuWrQt/Z+sh8UVEpBlBZ3m3KNPz2kFu7KgRTQx/C9o4/TdquPD1jOqjQ==",
       "dev": true,
       "peerDependencies": {
         "@volar/vue-language-plugin-pug": "^1.0.4",
@@ -4475,9 +4475,9 @@
       "dev": true
     },
     "prettier-plugin-organize-imports": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-3.2.0.tgz",
-      "integrity": "sha512-jeZ13YVKgXYCzkuwnoR6saKxJmdRYWMxS2G/su1V3qDWqTo1Q5iSoTblBxsXXAmomXfPqa/uA7YCK0/S86KLOQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-3.2.1.tgz",
+      "integrity": "sha512-bty7C2Ecard5EOXirtzeCAqj4FU4epeuWrQt/Z+sh8UVEpBlBZ3m3KNPz2kFu7KgRTQx/C9o4/TdquPD1jOqjQ==",
       "dev": true
     },
     "private-ip": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ttv-lol-pro",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ttv-lol-pro",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "GPL-3.0",
       "dependencies": {
         "private-ip": "^2.3.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,11 +12,11 @@
         "private-ip": "^2.3.4"
       },
       "devDependencies": {
-        "@parcel/config-webextension": "^2.7.0",
+        "@parcel/config-webextension": "^2.8.0",
         "@types/webextension-polyfill": "^0.9.1",
-        "parcel": "^2.7.0",
-        "prettier": "^2.7.1",
-        "typescript": "^4.8.4",
+        "parcel": "^2.8.0",
+        "prettier": "^2.8.0",
+        "typescript": "^4.9.3",
         "webextension-polyfill": "^0.10.0"
       }
     },
@@ -166,9 +166,9 @@
       "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.16",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.16.tgz",
-      "integrity": "sha512-LCQ+NeThyJ4k1W2d+vIKdxuSt9R3pQSZ4P92m7EakaYuXcVWbHuT5bjNcqLd4Rdgi6xYWYDvBJZJLZSLanjDcA==",
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
+      "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
       "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "3.1.0",
@@ -283,9 +283,9 @@
       }
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-2.1.2.tgz",
-      "integrity": "sha512-TyVLn3S/+ikMDsh0gbKv2YydKClN8HaJDDpONlaZR+LVJmsxLFUgA+O7zu59h9+f9gX1aj/ahw9wqa6rosmrYQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-2.2.0.tgz",
+      "integrity": "sha512-Z9LFPzfoJi4mflGWV+rv7o7ZbMU5oAU9VmzCgL240KnqDW65Y2HFCT3MW06/ITJSnbVLacmcEJA8phywK7JinQ==",
       "cpu": [
         "arm64"
       ],
@@ -296,9 +296,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-2.1.2.tgz",
-      "integrity": "sha512-YPXtcVkhmVNoMGlqp81ZHW4dMxK09msWgnxtsDpSiZwTzUBG2N+No2bsr7WMtBKCVJMSD6mbAl7YhKUqkp/Few==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-2.2.0.tgz",
+      "integrity": "sha512-vq0tT8sjZsy4JdSqmadWVw6f66UXqUCabLmUVHZwUFzMgtgoIIQjT4VVRHKvlof3P/dMCkbMJ5hB1oJ9OWHaaw==",
       "cpu": [
         "x64"
       ],
@@ -309,9 +309,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-2.1.2.tgz",
-      "integrity": "sha512-42R4MAFeIeNn+L98qwxAt360bwzX2Kf0ZQkBBucJ2Ircza3asoY4CDbgiu9VWklq8gWJVSJSJBwDI+c/THiWkA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-2.2.0.tgz",
+      "integrity": "sha512-SaJ3Qq4lX9Syd2xEo9u3qPxi/OB+5JO/ngJKK97XDpa1C587H9EWYO6KD8995DAjSinWvdHKRrCOXVUC5fvGOg==",
       "cpu": [
         "arm"
       ],
@@ -322,9 +322,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-2.1.2.tgz",
-      "integrity": "sha512-vHZ2JiOWF2+DN9lzltGbhtQNzDo8fKFGrf37UJrgqxU0yvtERrzUugnfnX1wmVfFhSsF8OxrfqiNOUc5hko1Zg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-2.2.0.tgz",
+      "integrity": "sha512-hlxxLdRmPyq16QCutUtP8Tm6RDWcyaLsRssaHROatgnkOxdleMTgetf9JsdncL8vLh7FVy/RN9i3XR5dnb9cRA==",
       "cpu": [
         "arm64"
       ],
@@ -335,9 +335,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-2.1.2.tgz",
-      "integrity": "sha512-RjRoRxg7Q3kPAdUSC5EUUPlwfMkIVhmaRTIe+cqHbKrGZ4M6TyCA/b5qMaukQ/1CHWrqYY2FbKOAU8Hg0pQFzg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-2.2.0.tgz",
+      "integrity": "sha512-94y5PJrSOqUNcFKmOl7z319FelCLAE0rz/jPCWS+UtdMZvpa4jrQd+cJPQCLp2Fes1yAW/YUQj/Di6YVT3c3Iw==",
       "cpu": [
         "x64"
       ],
@@ -348,9 +348,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-2.1.2.tgz",
-      "integrity": "sha512-rIZVR48zA8hGkHIK7ED6+ZiXsjRCcAVBJbm8o89OKAMTmEAQ2QvoOxoiu3w2isAaWwzgtQIOFIqHwvZDyLKCvw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-2.2.0.tgz",
+      "integrity": "sha512-XrC0JzsqQSvOyM3t04FMLO6z5gCuhPE6k4FXuLK5xf52ZbdvcFe1yBmo7meCew9B8G2f0T9iu9t3kfTYRYROgA==",
       "cpu": [
         "x64"
       ],
@@ -361,20 +361,21 @@
       ]
     },
     "node_modules/@parcel/bundler-default": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.7.0.tgz",
-      "integrity": "sha512-PU5MtWWhc+dYI9x8mguYnm9yiG6TkI7niRpxgJgtqAyGHuEyNXVBQQ0X+qyOF4D9LdankBf8uNN18g31IET2Zg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.8.0.tgz",
+      "integrity": "sha512-OvDDhxX4LwfGe7lYVMbJMzqNcDk8ydOqNw0Hra9WPgl0m5gju/eVIbDvot3JXp5F96FmV36uCxdODJhKTNoAzQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/hash": "2.7.0",
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/diagnostic": "2.8.0",
+        "@parcel/graph": "2.8.0",
+        "@parcel/hash": "2.8.0",
+        "@parcel/plugin": "2.8.0",
+        "@parcel/utils": "2.8.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.8.0"
       },
       "funding": {
         "type": "opencollective",
@@ -382,14 +383,14 @@
       }
     },
     "node_modules/@parcel/cache": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.7.0.tgz",
-      "integrity": "sha512-JlXNoZXcWzLKdDlfeF3dIj5Vtel5T9vtdBN72PJ+cjC4qNHk4Uwvc5sfOBELuibGN0bVu2bwY9nUgSwCiB1iIA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.8.0.tgz",
+      "integrity": "sha512-k945hrafMDR2wyCKyZYgwypeLLuZWce6FzhgunI4taBUeVnNCcpFAWzbfOVQ39SqZTGDqG3MNT+VuehssHXxyg==",
       "dev": true,
       "dependencies": {
-        "@parcel/fs": "2.7.0",
-        "@parcel/logger": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/fs": "2.8.0",
+        "@parcel/logger": "2.8.0",
+        "@parcel/utils": "2.8.0",
         "lmdb": "2.5.2"
       },
       "engines": {
@@ -400,13 +401,13 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.7.0"
+        "@parcel/core": "^2.8.0"
       }
     },
     "node_modules/@parcel/codeframe": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.7.0.tgz",
-      "integrity": "sha512-UTKx0jejJmmO1dwTHSJuRgrO8N6PMlkxRT6sew8N6NC3Bgv6pu0EbO+RtlWt/jCvzcdLOPdIoTzj4MMZvgcMYg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.8.0.tgz",
+      "integrity": "sha512-821d+KVcpEvJNMj9WMC39xXZK6zvRS/HUjQag2f3DkcRcZwk1uXJZdW6p1EB7C3e4e/0KSK3NTSVGEvbOSR+9w==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.0"
@@ -420,16 +421,16 @@
       }
     },
     "node_modules/@parcel/compressor-raw": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.7.0.tgz",
-      "integrity": "sha512-SCXwnOOQT6EmpusBsYWNQ/RFri+2JnKuE0gMSf2dROl2xbererX45FYzeDplWALCKAdjMNDpFwU+FyMYoVZSCQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.8.0.tgz",
+      "integrity": "sha512-tM49t0gDQnwJbrDCeoCn9LRc8inZ/TSPQTttJTfcmFHHFqEllI0ZDVG0AiQw5NOMQbBLYiKun1adXn8pkcPLEA==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.7.0"
+        "@parcel/plugin": "2.8.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.8.0"
       },
       "funding": {
         "type": "opencollective",
@@ -437,90 +438,90 @@
       }
     },
     "node_modules/@parcel/config-default": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.7.0.tgz",
-      "integrity": "sha512-ZzsLr97AYrz8c9k6qn3DlqPzifi3vbP7q3ynUrAFxmt0L4+K0H9N508ZkORYmCgaFjLIQ8Y3eWpwCJ0AewPNIg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.8.0.tgz",
+      "integrity": "sha512-j9g50QNSLjuNpY0TP01EgGJPxWNes9d+e8+N07Z5Wv0u+UUnJ2uIOpo7PVn7ullOGhm1f9lP4KsJenu5gWb+cg==",
       "dev": true,
       "dependencies": {
-        "@parcel/bundler-default": "2.7.0",
-        "@parcel/compressor-raw": "2.7.0",
-        "@parcel/namer-default": "2.7.0",
-        "@parcel/optimizer-css": "2.7.0",
-        "@parcel/optimizer-htmlnano": "2.7.0",
-        "@parcel/optimizer-image": "2.7.0",
-        "@parcel/optimizer-svgo": "2.7.0",
-        "@parcel/optimizer-terser": "2.7.0",
-        "@parcel/packager-css": "2.7.0",
-        "@parcel/packager-html": "2.7.0",
-        "@parcel/packager-js": "2.7.0",
-        "@parcel/packager-raw": "2.7.0",
-        "@parcel/packager-svg": "2.7.0",
-        "@parcel/reporter-dev-server": "2.7.0",
-        "@parcel/resolver-default": "2.7.0",
-        "@parcel/runtime-browser-hmr": "2.7.0",
-        "@parcel/runtime-js": "2.7.0",
-        "@parcel/runtime-react-refresh": "2.7.0",
-        "@parcel/runtime-service-worker": "2.7.0",
-        "@parcel/transformer-babel": "2.7.0",
-        "@parcel/transformer-css": "2.7.0",
-        "@parcel/transformer-html": "2.7.0",
-        "@parcel/transformer-image": "2.7.0",
-        "@parcel/transformer-js": "2.7.0",
-        "@parcel/transformer-json": "2.7.0",
-        "@parcel/transformer-postcss": "2.7.0",
-        "@parcel/transformer-posthtml": "2.7.0",
-        "@parcel/transformer-raw": "2.7.0",
-        "@parcel/transformer-react-refresh-wrap": "2.7.0",
-        "@parcel/transformer-svg": "2.7.0"
+        "@parcel/bundler-default": "2.8.0",
+        "@parcel/compressor-raw": "2.8.0",
+        "@parcel/namer-default": "2.8.0",
+        "@parcel/optimizer-css": "2.8.0",
+        "@parcel/optimizer-htmlnano": "2.8.0",
+        "@parcel/optimizer-image": "2.8.0",
+        "@parcel/optimizer-svgo": "2.8.0",
+        "@parcel/optimizer-terser": "2.8.0",
+        "@parcel/packager-css": "2.8.0",
+        "@parcel/packager-html": "2.8.0",
+        "@parcel/packager-js": "2.8.0",
+        "@parcel/packager-raw": "2.8.0",
+        "@parcel/packager-svg": "2.8.0",
+        "@parcel/reporter-dev-server": "2.8.0",
+        "@parcel/resolver-default": "2.8.0",
+        "@parcel/runtime-browser-hmr": "2.8.0",
+        "@parcel/runtime-js": "2.8.0",
+        "@parcel/runtime-react-refresh": "2.8.0",
+        "@parcel/runtime-service-worker": "2.8.0",
+        "@parcel/transformer-babel": "2.8.0",
+        "@parcel/transformer-css": "2.8.0",
+        "@parcel/transformer-html": "2.8.0",
+        "@parcel/transformer-image": "2.8.0",
+        "@parcel/transformer-js": "2.8.0",
+        "@parcel/transformer-json": "2.8.0",
+        "@parcel/transformer-postcss": "2.8.0",
+        "@parcel/transformer-posthtml": "2.8.0",
+        "@parcel/transformer-raw": "2.8.0",
+        "@parcel/transformer-react-refresh-wrap": "2.8.0",
+        "@parcel/transformer-svg": "2.8.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.7.0"
+        "@parcel/core": "^2.8.0"
       }
     },
     "node_modules/@parcel/config-webextension": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/config-webextension/-/config-webextension-2.7.0.tgz",
-      "integrity": "sha512-5OBhrRfsamI5oInv2APMgz9+qSqDhb07iR98qhRMYt2S34/Npj08vrUtqr2nZiiA5ypThT+FRtRjYAtiHPQMSQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/config-webextension/-/config-webextension-2.8.0.tgz",
+      "integrity": "sha512-80gtgNU77kT1DY9SXNt8CwBgHLu5qWwmo0sw2SCMzg+iXYSj8WAuESAN56O6J+Su3IWs+IzF6MdCAYFTyGM5mA==",
       "dev": true,
       "dependencies": {
-        "@parcel/config-default": "2.7.0",
-        "@parcel/packager-webextension": "2.7.0",
-        "@parcel/runtime-webextension": "2.7.0",
-        "@parcel/transformer-raw": "2.7.0",
-        "@parcel/transformer-webextension": "2.7.0"
+        "@parcel/config-default": "2.8.0",
+        "@parcel/packager-webextension": "2.8.0",
+        "@parcel/runtime-webextension": "2.8.0",
+        "@parcel/transformer-raw": "2.8.0",
+        "@parcel/transformer-webextension": "2.8.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.7.0"
+        "@parcel/core": "^2.8.0"
       }
     },
     "node_modules/@parcel/core": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.7.0.tgz",
-      "integrity": "sha512-7yKZUdh314Q/kU/9+27ZYTfcnXS6VYHuG+iiUlIohnvUUybxLqVJhdMU9Q+z2QcPka1IdJWz4K4Xx0y6/4goyg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.8.0.tgz",
+      "integrity": "sha512-udzbe3jjbpfKlRE9pdlROAa+lvAjS1L/AzN6r2j1y/Fsn7ze/NfvnCFw6o2YNIrXg002aQ7M1St/x1fdGfmVKA==",
       "dev": true,
       "dependencies": {
         "@mischnic/json-sourcemap": "^0.1.0",
-        "@parcel/cache": "2.7.0",
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/events": "2.7.0",
-        "@parcel/fs": "2.7.0",
-        "@parcel/graph": "2.7.0",
-        "@parcel/hash": "2.7.0",
-        "@parcel/logger": "2.7.0",
-        "@parcel/package-manager": "2.7.0",
-        "@parcel/plugin": "2.7.0",
-        "@parcel/source-map": "^2.0.0",
-        "@parcel/types": "2.7.0",
-        "@parcel/utils": "2.7.0",
-        "@parcel/workers": "2.7.0",
+        "@parcel/cache": "2.8.0",
+        "@parcel/diagnostic": "2.8.0",
+        "@parcel/events": "2.8.0",
+        "@parcel/fs": "2.8.0",
+        "@parcel/graph": "2.8.0",
+        "@parcel/hash": "2.8.0",
+        "@parcel/logger": "2.8.0",
+        "@parcel/package-manager": "2.8.0",
+        "@parcel/plugin": "2.8.0",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/types": "2.8.0",
+        "@parcel/utils": "2.8.0",
+        "@parcel/workers": "2.8.0",
         "abortcontroller-polyfill": "^1.1.9",
         "base-x": "^3.0.8",
         "browserslist": "^4.6.6",
@@ -540,26 +541,10 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/@parcel/css": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@parcel/css/-/css-1.14.0.tgz",
-      "integrity": "sha512-r5tJWe6NF6lesfPw1N3g7N7WUKpHqi2ONnw9wl5ccSGGIxkmgcPaPQxfvmhdjXvQnktSuIOR0HjQXVXu+/en/w==",
-      "dev": true,
-      "dependencies": {
-        "lightningcss": "^1.14.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
     "node_modules/@parcel/diagnostic": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.7.0.tgz",
-      "integrity": "sha512-pdq/cTwVoL0n8yuDCRXFRSQHVWdmmIXPt3R3iT4KtYDYvOrMT2dLPT79IMqQkhYPANW8GuL15n/WxRngfRdkug==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.8.0.tgz",
+      "integrity": "sha512-ERnk0zDvm0jQUSj1M+2PLiwVC6nWrtuFEuye6VGuxRDcp9NHbz6gwApeEYxFkPsb3TQPhNjnXXm5nmAw1bpWWw==",
       "dev": true,
       "dependencies": {
         "@mischnic/json-sourcemap": "^0.1.0",
@@ -574,9 +559,9 @@
       }
     },
     "node_modules/@parcel/events": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.7.0.tgz",
-      "integrity": "sha512-kQDwMKgZ1U4M/G17qeDYF6bW5kybluN6ajYPc7mZcrWg+trEI/oXi81GMFaMX0BSUhwhbiN5+/Vb2wiG/Sn6ig==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.8.0.tgz",
+      "integrity": "sha512-xqSZYY3oONM4IZm9+vhyFqX+KFIl145veIczUikwGJlcJZQfAAw736syPx6ecpB+m1EVg3AlvJWy7Lmel4Ak+Q==",
       "dev": true,
       "engines": {
         "node": ">= 12.0.0"
@@ -587,16 +572,16 @@
       }
     },
     "node_modules/@parcel/fs": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.7.0.tgz",
-      "integrity": "sha512-PU5fo4Hh8y03LZgemgVREttc0wyHQUNmsJCybxTB7EjJie2CqJRumo+DFppArlvdchLwJdc9em03yQV/GNWrEg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.8.0.tgz",
+      "integrity": "sha512-v3DbJlpl8v2/VRlZPw7cy+0myi0YfLblGZcwDvqIsWS35qyxD2rmtYV8u1BusonbgmJeaKiopSECmJkumt0jCw==",
       "dev": true,
       "dependencies": {
-        "@parcel/fs-search": "2.7.0",
-        "@parcel/types": "2.7.0",
-        "@parcel/utils": "2.7.0",
-        "@parcel/watcher": "^2.0.0",
-        "@parcel/workers": "2.7.0"
+        "@parcel/fs-search": "2.8.0",
+        "@parcel/types": "2.8.0",
+        "@parcel/utils": "2.8.0",
+        "@parcel/watcher": "^2.0.7",
+        "@parcel/workers": "2.8.0"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -606,13 +591,13 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.7.0"
+        "@parcel/core": "^2.8.0"
       }
     },
     "node_modules/@parcel/fs-search": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/fs-search/-/fs-search-2.7.0.tgz",
-      "integrity": "sha512-K1Hv25bnRpwQVA15RvcRuB8ZhfclnCHA8N8L6w7Ul1ncSJDxCIkIAc5hAubYNNYW3kWjCC2SOaEgFKnbvMllEQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/fs-search/-/fs-search-2.8.0.tgz",
+      "integrity": "sha512-yo7/Y8DCFlhOlIBb5SsRDTkM+7g0DY9sK57iw3hn2z1tGoIiIRptrieImFYSizs7HfDwDY/PMLfORmUdoReDzQ==",
       "dev": true,
       "dependencies": {
         "detect-libc": "^1.0.3"
@@ -626,12 +611,12 @@
       }
     },
     "node_modules/@parcel/graph": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-2.7.0.tgz",
-      "integrity": "sha512-Q6E94GS6q45PtsZh+m+gvFRp/N1Qopxhu2sxjcWsGs5iBd6IWn2oYLWOH5iVzEjWuYpW2HkB08lH6J50O63uOA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-2.8.0.tgz",
+      "integrity": "sha512-JvAyvBpGmhZ30bi+hStQr52eu+InfJBoiN9Z/32byIWhXEl02EAOwfsPqAe+FGCsdgXnnCGg5F9ZCqwzZ9dwbw==",
       "dev": true,
       "dependencies": {
-        "@parcel/utils": "2.7.0",
+        "@parcel/utils": "2.8.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -643,9 +628,9 @@
       }
     },
     "node_modules/@parcel/hash": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/hash/-/hash-2.7.0.tgz",
-      "integrity": "sha512-k6bSKnIlPJMPU3yjQzfgfvF9zuJZGOAlJgzpL4BbWvdbE8BTdjzLcFn0Ujrtud94EgIkiXd22sC2HpCUWoHGdA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/hash/-/hash-2.8.0.tgz",
+      "integrity": "sha512-KV1+96t7Nukth5K7ldUXjVr8ZTH9Dohl49K0Tc+5Qkysif0OxwcDtpVDmcnrUnWmqdBX0AdoLY0Q2Nnly89n/w==",
       "dev": true,
       "dependencies": {
         "detect-libc": "^1.0.3",
@@ -660,13 +645,13 @@
       }
     },
     "node_modules/@parcel/logger": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.7.0.tgz",
-      "integrity": "sha512-qjMY/bYo38+o+OiIrTRldU9CwL1E7J72t+xkTP8QIcUxLWz5LYR0YbynZUVulmBSfqsykjjxCy4a+8siVr+lPw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.0.tgz",
+      "integrity": "sha512-W+7rKsLxLUX6xRmP8PhGWcG48PqrzTPeMWpgSds5nXxAHEFh4cYbkwPKGoTU65a9xUDVyqNreHNIKyizgwAZHQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/events": "2.7.0"
+        "@parcel/diagnostic": "2.8.0",
+        "@parcel/events": "2.8.0"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -677,9 +662,9 @@
       }
     },
     "node_modules/@parcel/markdown-ansi": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.7.0.tgz",
-      "integrity": "sha512-ipOX0D6FVZFEXeb/z8MnTMq2RQEIuaILY90olVIuHEFLHHfOPEn+RK3u13HA1ChF5/9E3cMD79tu6x9JL9Kqag==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.8.0.tgz",
+      "integrity": "sha512-xItzXmc3btFhJXsIbE946iaqE6STd2xe5H0zSIaZVXEeucCtMzcd4hxRELquxPstlrAOrrp/lrRpbAlMhso9iA==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.0"
@@ -693,18 +678,18 @@
       }
     },
     "node_modules/@parcel/namer-default": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.7.0.tgz",
-      "integrity": "sha512-lIKMdsmi//7fepecNDYmJYzBlL91HifPsX03lJCdu1dC6q5fBs+gG0XjKKG7yPnSCw1qH/4m7drzt9+dRZYAHQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.8.0.tgz",
+      "integrity": "sha512-cVCx2kJA/Bv7O9pVad1UOibaybR/B+QdWV8Ols8HH4lC2gyjLBXEIR0uuPSEbkGwMEcofG6zA3MwsoPa6r5lBg==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/plugin": "2.7.0",
+        "@parcel/diagnostic": "2.8.0",
+        "@parcel/plugin": "2.8.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.8.0"
       },
       "funding": {
         "type": "opencollective",
@@ -712,13 +697,13 @@
       }
     },
     "node_modules/@parcel/node-resolver-core": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-2.7.0.tgz",
-      "integrity": "sha512-5UJQHalqMxdhJIs2hhqQzFfQpF7+NAowsRq064lYtiRvcD8wMr3OOQ9wd1iazGpFSl4JKdT7BwDU9/miDJmanQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-2.8.0.tgz",
+      "integrity": "sha512-cECSh08NSRt1csmmMeKxlnO6ZhXRTuRijkHKFa4iG5hPL+3Cu04YGhuK/QWlP5vNCPVrH3ISlhzlPU5fAi/nEg==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/diagnostic": "2.8.0",
+        "@parcel/utils": "2.8.0",
         "nullthrows": "^1.1.1",
         "semver": "^5.7.1"
       },
@@ -731,22 +716,22 @@
       }
     },
     "node_modules/@parcel/optimizer-css": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.7.0.tgz",
-      "integrity": "sha512-IfnOMACqhcAclKyOW9X9JpsknB6OShk9OVvb8EvbDTKHJhQHNNmzE88OkSI/pS3ZVZP9Zj+nWcVHguV+kvDeiQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.8.0.tgz",
+      "integrity": "sha512-T5r3gZVm1xFw6l//iLkzLDUvFzNTUvL5kAtyU5gS5yH/dg7eCS09Km/c2anViQnmXwFUt7zIlBovj1doxAVNSw==",
       "dev": true,
       "dependencies": {
-        "@parcel/css": "^1.12.2",
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/plugin": "2.7.0",
-        "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/diagnostic": "2.8.0",
+        "@parcel/plugin": "2.8.0",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/utils": "2.8.0",
         "browserslist": "^4.6.6",
+        "lightningcss": "^1.16.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.8.0"
       },
       "funding": {
         "type": "opencollective",
@@ -754,12 +739,12 @@
       }
     },
     "node_modules/@parcel/optimizer-htmlnano": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.7.0.tgz",
-      "integrity": "sha512-5QrGdWS5Hi4VXE3nQNrGqugmSXt68YIsWwKRAdarOxzyULSJS3gbCiQOXqIPRJobfZjnSIcdtkyxSiCUe1inIA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.8.0.tgz",
+      "integrity": "sha512-NxEKTRvue/WAU+XbQGfNIU6c7chDekdkwwv9YnCxHEOhnBu4Ok+2tdmCtPuA+4UUNszGxXlaHMnqSrjmqX2S6Q==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.7.0",
+        "@parcel/plugin": "2.8.0",
         "htmlnano": "^2.0.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
@@ -767,7 +752,7 @@
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.8.0"
       },
       "funding": {
         "type": "opencollective",
@@ -775,20 +760,20 @@
       }
     },
     "node_modules/@parcel/optimizer-image": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.7.0.tgz",
-      "integrity": "sha512-EnaXz5UjR67FUu0BEcqZTT9LsbB/iFAkkghCotbnbOuC5QQsloq6tw54TKU3y+R3qsjgUoMtGxPcGfVoXxZXYw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.8.0.tgz",
+      "integrity": "sha512-66eSoCCGZVRiY6U4OqqYrhQcBcHI9cOkIEbxadZYOF4cJhsskjUDJR0jLb4j2PE6QxUNYlyj5OglQqRLwhz7vA==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0",
-        "@parcel/workers": "2.7.0",
+        "@parcel/diagnostic": "2.8.0",
+        "@parcel/plugin": "2.8.0",
+        "@parcel/utils": "2.8.0",
+        "@parcel/workers": "2.8.0",
         "detect-libc": "^1.0.3"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.8.0"
       },
       "funding": {
         "type": "opencollective",
@@ -796,19 +781,19 @@
       }
     },
     "node_modules/@parcel/optimizer-svgo": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-svgo/-/optimizer-svgo-2.7.0.tgz",
-      "integrity": "sha512-IO1JV4NpfP3V7FrhsqCcV8pDQIHraFi1/ZvEJyssITxjH49Im/txKlwMiQuZZryAPn8Xb8g395Muawuk6AK6sg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-svgo/-/optimizer-svgo-2.8.0.tgz",
+      "integrity": "sha512-qQzM32CzJJuniFaTZDspVn/Vtz/PJ/f89+FckLpWZJVWNihgwTHC1/F0YTDH8g6czNw5ZijwQ3xBVuJQYyIXsQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/diagnostic": "2.8.0",
+        "@parcel/plugin": "2.8.0",
+        "@parcel/utils": "2.8.0",
         "svgo": "^2.4.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.8.0"
       },
       "funding": {
         "type": "opencollective",
@@ -816,21 +801,21 @@
       }
     },
     "node_modules/@parcel/optimizer-terser": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-terser/-/optimizer-terser-2.7.0.tgz",
-      "integrity": "sha512-07VZjIO8xsl2/WmS/qHI8lI/cpu47iS9eRpqwfZEEsdk1cfz50jhWkmFudHBxiHGMfcZ//1+DdaPg9RDBWZtZA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-terser/-/optimizer-terser-2.8.0.tgz",
+      "integrity": "sha512-slS6GWQ3u418WtJmlqlA5Njljcq4OaEdDDR2ifEwltG8POv+hsvD5AAoM2XB0GJwY97TQtdMbBu2DuDF3yM/1Q==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/plugin": "2.7.0",
-        "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/diagnostic": "2.8.0",
+        "@parcel/plugin": "2.8.0",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/utils": "2.8.0",
         "nullthrows": "^1.1.1",
         "terser": "^5.2.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.8.0"
       },
       "funding": {
         "type": "opencollective",
@@ -838,17 +823,17 @@
       }
     },
     "node_modules/@parcel/package-manager": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.7.0.tgz",
-      "integrity": "sha512-wmfSX1mRrTi8MeA4KrnPk/x7zGUsILCQmTo6lA4gygzAxDbM1pGuyFN8/Kt0y0SFO2lbljARtD/4an5qdotH+Q==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.8.0.tgz",
+      "integrity": "sha512-n4FgerAX1lTKKTgxmiocnos47Y+b0L60iwU6Q4cC2n4KQNRuNyfhxFXwWcqHstR9wa72JgPaDgo4k0l3Bk8FZw==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/fs": "2.7.0",
-        "@parcel/logger": "2.7.0",
-        "@parcel/types": "2.7.0",
-        "@parcel/utils": "2.7.0",
-        "@parcel/workers": "2.7.0",
+        "@parcel/diagnostic": "2.8.0",
+        "@parcel/fs": "2.8.0",
+        "@parcel/logger": "2.8.0",
+        "@parcel/types": "2.8.0",
+        "@parcel/utils": "2.8.0",
+        "@parcel/workers": "2.8.0",
         "semver": "^5.7.1"
       },
       "engines": {
@@ -859,23 +844,23 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.7.0"
+        "@parcel/core": "^2.8.0"
       }
     },
     "node_modules/@parcel/packager-css": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.7.0.tgz",
-      "integrity": "sha512-44nzZwu+ssGuiFmYM6cf/Y4iChiUZ4DUzzpegnGlhXtKJKe4NHntxThJynuRZWKN2AAf48avApDpimg2jW0KDw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.8.0.tgz",
+      "integrity": "sha512-tv/Bto0P6fXjqQ9uCZ8/6b/+38Zr/N2MC7/Nbflzww/lp0k2+kkE9MVJJDr5kST/SzTBRrhbDo+yTbtdZikJYg==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/plugin": "2.8.0",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/utils": "2.8.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.8.0"
       },
       "funding": {
         "type": "opencollective",
@@ -883,20 +868,20 @@
       }
     },
     "node_modules/@parcel/packager-html": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.7.0.tgz",
-      "integrity": "sha512-Zgqd7sdcY/UnR370GR0q2ilmEohUDXsO8A1F28QCJzIsR1iCB6KRUT74+pawfQ1IhXZLaaFLLYe0UWcfm0JeXg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.8.0.tgz",
+      "integrity": "sha512-4x09v/bt767rxwGTuEw82CjheoOtIKNu4sx1gqwQOz9QowKPniXOIaD+0XmLiARdzRErucf0sL19QHfNcPAhUw==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/types": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/plugin": "2.8.0",
+        "@parcel/types": "2.8.0",
+        "@parcel/utils": "2.8.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.8.0"
       },
       "funding": {
         "type": "opencollective",
@@ -904,22 +889,22 @@
       }
     },
     "node_modules/@parcel/packager-js": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.7.0.tgz",
-      "integrity": "sha512-wTRdM81PgRVDzWGXdWmqLwguWnTYWzhEDdjXpW2n8uMOu/CjHhMtogk65aaYk3GOnq6OBL/NsrmBiV/zKPj1vA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.8.0.tgz",
+      "integrity": "sha512-Tn2EtWM1TEdj4t5pt0QjBDzqrXrfRTL3WsdMipZwDSuX04KS0jedJINHjh46HOMwyfJxLbUg3xkGX7F5mYQj5g==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/hash": "2.7.0",
-        "@parcel/plugin": "2.7.0",
-        "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/diagnostic": "2.8.0",
+        "@parcel/hash": "2.8.0",
+        "@parcel/plugin": "2.8.0",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/utils": "2.8.0",
         "globals": "^13.2.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.8.0"
       },
       "funding": {
         "type": "opencollective",
@@ -927,16 +912,16 @@
       }
     },
     "node_modules/@parcel/packager-raw": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.7.0.tgz",
-      "integrity": "sha512-jg2Zp8dI5VpIQlaeahXDCfrPN9m/DKht1NkR9P2CylMAwqCcc1Xc1RRiF0wfwcPZpPMpq1265n+4qnB7rjGBlA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.8.0.tgz",
+      "integrity": "sha512-s3VniER3X2oNTlfytBGIQF+UZFVNLFWuVu1IkZ8Wg6uYQffrExDlbNDcmFCDcfvcejL3Ch5igP+L6N00f6+wAQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.7.0"
+        "@parcel/plugin": "2.8.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.8.0"
       },
       "funding": {
         "type": "opencollective",
@@ -944,19 +929,19 @@
       }
     },
     "node_modules/@parcel/packager-svg": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.7.0.tgz",
-      "integrity": "sha512-EmJg3HpD6/xxKBjir/CdCKJZwI24iVfBuxRS9LUp3xHAIebOzVh1z6IN+i2Di5+NyRwfOFaLliL4uMa1zwbyCA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.8.0.tgz",
+      "integrity": "sha512-+BSpdPiNjlAne28nOjG2AyiOejAehe/+X9MxL2FIpPP7UBLNc2ekaM0mDTR5iY45YtZa57oyErBT/U6wZ1TCjw==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/types": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/plugin": "2.8.0",
+        "@parcel/types": "2.8.0",
+        "@parcel/utils": "2.8.0",
         "posthtml": "^0.16.4"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.8.0"
       },
       "funding": {
         "type": "opencollective",
@@ -964,18 +949,18 @@
       }
     },
     "node_modules/@parcel/packager-webextension": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-webextension/-/packager-webextension-2.7.0.tgz",
-      "integrity": "sha512-HoGE/6S+beiFuLhYWUctA1UHtN1YIuTeqP3JitDwGEMz2iMaffajTP+8LNGqZjB3X+98rVYiNLdk0uEWUs70kw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-webextension/-/packager-webextension-2.8.0.tgz",
+      "integrity": "sha512-ODB3sTXk/qyivK0JcM+kw9MV5pWigqppIOXQAK5zPv4sYHlMNuZJiANKizs5aP1+9Iz5ludU1wM1qMe1n/xDiw==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/plugin": "2.8.0",
+        "@parcel/utils": "2.8.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">=12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.8.0"
       },
       "funding": {
         "type": "opencollective",
@@ -983,12 +968,12 @@
       }
     },
     "node_modules/@parcel/plugin": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.7.0.tgz",
-      "integrity": "sha512-qqgx+nnMn6/0lRc4lKbLGmhNtBiT93S2gFNB4Eb4Pfz/SxVYoW+fmml+KdfOSiZffWOAH5L6NwhyD7N8aSikzw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.8.0.tgz",
+      "integrity": "sha512-Tsf+7nDg7KauvTVY6rGc7CmgJruKSwJ54KJ9s5nYFFP9nfwmyqbayCi9xOxicWU9zIHfuF5Etwf17lcA0oAvzw==",
       "dev": true,
       "dependencies": {
-        "@parcel/types": "2.7.0"
+        "@parcel/types": "2.8.0"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -999,20 +984,20 @@
       }
     },
     "node_modules/@parcel/reporter-cli": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.7.0.tgz",
-      "integrity": "sha512-80gEODg8cnAmnxGVuaSVDo8JJ54P9AA2bHwSs1cIkHWlJ3BjDQb83H31bBHncJ5Kn5kQ/j+7WjlqHpTCiOR9PA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.8.0.tgz",
+      "integrity": "sha512-ea4/Lp+2jDbzb/tfTgUKzYU51FK8wcewDoYNr06uL+wvx/vzYIDG0jHfzaOTasREnm7ECDr1Zu2Iknrgk1STqQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/types": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/plugin": "2.8.0",
+        "@parcel/types": "2.8.0",
+        "@parcel/utils": "2.8.0",
         "chalk": "^4.1.0",
         "term-size": "^2.2.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.8.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1020,17 +1005,17 @@
       }
     },
     "node_modules/@parcel/reporter-dev-server": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.7.0.tgz",
-      "integrity": "sha512-ySuou5addK8fGue8aXzo536BaEjMujDrEc1xkp4TasInXHVcA98b+SYX5NAZTGob5CxKvZQ5ylhg77zW30B+iA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.8.0.tgz",
+      "integrity": "sha512-wg6hUrQ8vUmvlP2fg8YEzYndmq7hWZ21ZgBv4So1Z65I+Qav85Uox7bjGLCSJwEAjdjFKfhV9RGULGzqh8vcAQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0"
+        "@parcel/plugin": "2.8.0",
+        "@parcel/utils": "2.8.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.8.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1038,17 +1023,17 @@
       }
     },
     "node_modules/@parcel/resolver-default": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.7.0.tgz",
-      "integrity": "sha512-v8TvWsbLK7/q7n4gv6OrYNbW18xUx4zKbVMGZb1u4yMhzEH4HFr1D9OeoTq3jk+ximAigds8B6triQbL5exF7A==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.8.0.tgz",
+      "integrity": "sha512-kO5W+O3Ql6NXNFS6lvfSSt1R+PxO1atNLYxZdVSM6+QQxRMiztfqzZs//RM+oUp+af6muDSUPlNs+RORX0fing==",
       "dev": true,
       "dependencies": {
-        "@parcel/node-resolver-core": "2.7.0",
-        "@parcel/plugin": "2.7.0"
+        "@parcel/node-resolver-core": "2.8.0",
+        "@parcel/plugin": "2.8.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.8.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1056,17 +1041,17 @@
       }
     },
     "node_modules/@parcel/runtime-browser-hmr": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.7.0.tgz",
-      "integrity": "sha512-PLbMLdclQeYsi2LkilZVGFV1n3y55G1jaBvby4ekedUZjMw3SWdMY2tDxgSDdFWfLCnYHJXdGUQSzGGi1kPzjA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.8.0.tgz",
+      "integrity": "sha512-zV5wGGvm1cDwWAzkwPUaKh6inWYKxq67YWY4G396PXLMxddM9SQC1c7iFM60OPnD4A+BMOLOy7N6//20h15Dlg==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0"
+        "@parcel/plugin": "2.8.0",
+        "@parcel/utils": "2.8.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.8.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1074,18 +1059,18 @@
       }
     },
     "node_modules/@parcel/runtime-js": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.7.0.tgz",
-      "integrity": "sha512-9/YUZTBNrSN2H6rbz/o1EOM0O7I3ZR/x9IDzxjJBD6Mi+0uCgCD02aedare/SNr1qgnbZZWmhpOzC+YgREcfLA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.8.0.tgz",
+      "integrity": "sha512-IwT1rX8ZamoYZv0clfswZemfXcIfk+YXwNsqXwzzh6TaMGagj/ZZl1llkn7ERQFq4EoLEoDGGkxqsrJjBp9NDQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/plugin": "2.8.0",
+        "@parcel/utils": "2.8.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.8.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1093,19 +1078,19 @@
       }
     },
     "node_modules/@parcel/runtime-react-refresh": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.7.0.tgz",
-      "integrity": "sha512-vDKO0rWqRzEpmvoZ4kkYUiSsTxT5NnH904BFPFxKI0wJCl6yEmPuEifmATo73OuYhP6jIP3Qfl1R4TtiDFPJ1Q==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.8.0.tgz",
+      "integrity": "sha512-a6uuZWkl+mJur2WLZKmpEqq1P06tvRwqGefYbE26DWpwXwU9dLpfnv/nT0hqCmVDHd2TkMyCffolSmq1vY05ew==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/plugin": "2.8.0",
+        "@parcel/utils": "2.8.0",
         "react-error-overlay": "6.0.9",
         "react-refresh": "^0.9.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.8.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1113,18 +1098,18 @@
       }
     },
     "node_modules/@parcel/runtime-service-worker": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.7.0.tgz",
-      "integrity": "sha512-uD2pAV0yV6+e7JaWH4KVPbG+zRCrxr/OACyS9tIh+Q/R1vRmh8zGM3yhdrcoiZ7tFOnM72vd6xY11eTrUsSVig==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.8.0.tgz",
+      "integrity": "sha512-Q3Q2O/axQbFi/5Z+BidLB3qhmYdZLTMDagZtsmyH7CktDkZVNV/0UoOGYlqoK06T4cww3XjLSEomXbBu9TlQKQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/plugin": "2.8.0",
+        "@parcel/utils": "2.8.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.8.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1132,18 +1117,18 @@
       }
     },
     "node_modules/@parcel/runtime-webextension": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-webextension/-/runtime-webextension-2.7.0.tgz",
-      "integrity": "sha512-+2gGOOR3HUJGdsr/tUsJjs9tvlOsp2rTgGKt77+s1lqU/DYxh/n6KCSy+7a2DYtnBtZxE6LQhX6g/p4C2hkmMg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-webextension/-/runtime-webextension-2.8.0.tgz",
+      "integrity": "sha512-pfE30DHlw55GOTxp5k5NkCk2ccgJouF/JtCgHaAJdLqiEoqltsta6yFhHQj9ZLUV1qtjd5MxfIs5xOVXGp8SHw==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/plugin": "2.8.0",
+        "@parcel/utils": "2.8.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.8.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1163,15 +1148,15 @@
       }
     },
     "node_modules/@parcel/transformer-babel": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.7.0.tgz",
-      "integrity": "sha512-7iklDXXnKH1530+QbI+e4kIJ+Q1puA1ulRS10db3aUJMj5GnvXGDFwhSZ7+T1ps66QHO7cVO29VlbqiRDarH1Q==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.8.0.tgz",
+      "integrity": "sha512-ie+wFe9pucdnRyX2PTN9amOHrhr/IOwUEAfTz/3dPydOYCuX7ErEngCpI9fBzdYE2AV6/noEwC2Mjeoyz9mT2A==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/plugin": "2.7.0",
-        "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/diagnostic": "2.8.0",
+        "@parcel/plugin": "2.8.0",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/utils": "2.8.0",
         "browserslist": "^4.6.6",
         "json5": "^2.2.0",
         "nullthrows": "^1.1.1",
@@ -1179,7 +1164,7 @@
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.8.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1187,22 +1172,22 @@
       }
     },
     "node_modules/@parcel/transformer-css": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.7.0.tgz",
-      "integrity": "sha512-J4EpWK9spQpXyNCmKK8Xnane0xW/1B/EAmfp7Fiv7g+5yUjY4ODf4KUugvE+Eb2gekPkhOKNHermO2KrX0/PFA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.8.0.tgz",
+      "integrity": "sha512-jCMQSfsxCoepblBAHCYMuNWNPQlqasoD6PfNftMdTlv12aUcnjNIYO9600TVLTL799CrEohljbXcfFn6hDGVWw==",
       "dev": true,
       "dependencies": {
-        "@parcel/css": "^1.12.2",
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/plugin": "2.7.0",
-        "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/diagnostic": "2.8.0",
+        "@parcel/plugin": "2.8.0",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/utils": "2.8.0",
         "browserslist": "^4.6.6",
+        "lightningcss": "^1.16.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.8.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1210,14 +1195,14 @@
       }
     },
     "node_modules/@parcel/transformer-html": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.7.0.tgz",
-      "integrity": "sha512-wYJl5rn81W+Rlk9oQwDJcjoVsWVDKyeri84FzmlGXOsg0EYgnqOiG+3MDM8GeZjfuGe5fuoum4eqZeS0WdUHXw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.8.0.tgz",
+      "integrity": "sha512-KLcZCWSIItZ1s12Sav3uvfTrwhX92craN9u7V3qUs8ld7ompTKsCdnf+gYmeCyISb5yiFDyYBvTGc1bOXvaDRQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/hash": "2.7.0",
-        "@parcel/plugin": "2.7.0",
+        "@parcel/diagnostic": "2.8.0",
+        "@parcel/hash": "2.8.0",
+        "@parcel/plugin": "2.8.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.10.1",
@@ -1226,7 +1211,7 @@
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.8.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1234,36 +1219,36 @@
       }
     },
     "node_modules/@parcel/transformer-image": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.7.0.tgz",
-      "integrity": "sha512-mhi9/R5/ULhCkL2COVIKhNFoLDiZwQgprdaTJr5fnODggVxEX5o7ebFV6KNLMTEkwZUJWoB1hL0ziI0++DtoFA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.8.0.tgz",
+      "integrity": "sha512-hJGsZxGlGEkiUvN8kCxA4DhB6/WrHzcIlZZYEgEien9pLctyc6np6idjdcyudPAhH3LwBPkiyeUfCvLAOA1zkA==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0",
-        "@parcel/workers": "2.7.0",
+        "@parcel/plugin": "2.8.0",
+        "@parcel/utils": "2.8.0",
+        "@parcel/workers": "2.8.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.8.0"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.7.0"
+        "@parcel/core": "^2.8.0"
       }
     },
     "node_modules/@parcel/transformer-js": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.7.0.tgz",
-      "integrity": "sha512-mzerR+D4rDomUSIk5RSTa2w+DXBdXUeQrpDO74WCDdpDi1lIl8ppFpqtmU7O6y6p8QsgkmS9b0g/vhcry6CJTA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.8.0.tgz",
+      "integrity": "sha512-C5WTkDRiJGBB9tZa1mBsZwsqZjYEKkOa4mdVym3dMokwhFLUga8WtK7kGw4fmXIq41U8ip4orywj+Rd4mvGVWg==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/plugin": "2.7.0",
-        "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.7.0",
-        "@parcel/workers": "2.7.0",
-        "@swc/helpers": "^0.4.2",
+        "@parcel/diagnostic": "2.8.0",
+        "@parcel/plugin": "2.8.0",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/utils": "2.8.0",
+        "@parcel/workers": "2.8.0",
+        "@swc/helpers": "^0.4.12",
         "browserslist": "^4.6.6",
         "detect-libc": "^1.0.3",
         "nullthrows": "^1.1.1",
@@ -1272,28 +1257,28 @@
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.8.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.7.0"
+        "@parcel/core": "^2.8.0"
       }
     },
     "node_modules/@parcel/transformer-json": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.7.0.tgz",
-      "integrity": "sha512-RQjuxBpYOch+kr4a0zi77KJtOLTPYRM7iq4NN80zKnA0r0dwDUCxZBtaj2l0O0o3R4MMJnm+ncP+cB7XR7dZYA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.8.0.tgz",
+      "integrity": "sha512-Pp5gROSMpzFDEI6KA2APuSpft6eXZxFgTPV6Xx9pElqseod3iL5+RnpMNV/nv76Ai2bcMEiafus5Pb09vjHgbQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.7.0",
+        "@parcel/plugin": "2.8.0",
         "json5": "^2.2.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.8.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1301,15 +1286,15 @@
       }
     },
     "node_modules/@parcel/transformer-postcss": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.7.0.tgz",
-      "integrity": "sha512-b6RskXBWf0MjpC9qjR2dQ1ZdRnlOiKYseG5CEovWCqM218RtdydFKz7jS+5Gxkb6qBtOG7zGPONXdPe+gTILcA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.8.0.tgz",
+      "integrity": "sha512-45Ij+cgwXprd1sCLmaMIlCbPz3eEwolGHizgZmXl5l4yjlE2wGyzodhxLpBk1PWu7OxxWRbLnJIlvMYf7Vfw0g==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/hash": "2.7.0",
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/diagnostic": "2.8.0",
+        "@parcel/hash": "2.8.0",
+        "@parcel/plugin": "2.8.0",
+        "@parcel/utils": "2.8.0",
         "clone": "^2.1.1",
         "nullthrows": "^1.1.1",
         "postcss-value-parser": "^4.2.0",
@@ -1317,7 +1302,7 @@
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.8.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1325,13 +1310,13 @@
       }
     },
     "node_modules/@parcel/transformer-posthtml": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.7.0.tgz",
-      "integrity": "sha512-cP8YOiSynWJ1ycmBlhnnHeuQb2cwmklZ+BNyLUktj5p78kDy2de7VjX+dRNRHoW4H9OgEcSF4UEfDVVz5RYIhw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.8.0.tgz",
+      "integrity": "sha512-KrkKBFDW5PNZpr2Ha711eIABQOiJQKvfwfVs3CVpJK5wSADkappDk7CQ0mISPjhamFJ6xx/sNsi7e871I8R9lg==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/plugin": "2.8.0",
+        "@parcel/utils": "2.8.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.10.1",
@@ -1340,7 +1325,7 @@
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.8.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1348,16 +1333,16 @@
       }
     },
     "node_modules/@parcel/transformer-raw": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.7.0.tgz",
-      "integrity": "sha512-sDnItWCFSDez0izK1i5cgv+kXzZTbcJh4rNpVIgmE1kBLvAz608sqgcCkavb2wVJIvLesxYM+5G4p1CwkDlZ1g==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.8.0.tgz",
+      "integrity": "sha512-uEbj+kE70vg2Gmdji/AIXPK13s5aQRw7X+xWs3vNpY2oymyMRHbfx1izJFWBh+kxu6Yo6q6qsekkh2rNHEHIUA==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.7.0"
+        "@parcel/plugin": "2.8.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.8.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1365,18 +1350,18 @@
       }
     },
     "node_modules/@parcel/transformer-react-refresh-wrap": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.7.0.tgz",
-      "integrity": "sha512-1vRmIJzyBA1nIiXTAU6tZExq2FvJj/2F0ft6KDw8GYPv0KjmdiPo/PmaZ7JeSVOM6SdXQIQCbTmp1vkMP7DtkA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.8.0.tgz",
+      "integrity": "sha512-d7G6wBdlwVXLkhC7EO/3UkUOfEOJvsIsQUCEujsrdFF+nfBElXw/TZ+KP8UkmrwMdD0spU/8cKoTyi5k19vt6w==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/plugin": "2.8.0",
+        "@parcel/utils": "2.8.0",
         "react-refresh": "^0.9.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.8.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1384,14 +1369,14 @@
       }
     },
     "node_modules/@parcel/transformer-svg": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.7.0.tgz",
-      "integrity": "sha512-ioER37zceuuE+K6ZrnjCyMUWEnv+63hIAFResc1OXxRhyt+7kzMz9ZqK0Mt6QMLwl1dxhkLmrU41n9IxzKZuSQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.8.0.tgz",
+      "integrity": "sha512-8S6yZoUTCbHOnuWY3M50fscTpI8414945I44fmed+C1e36TnWem8FifuVtGkRZeR8pokF453lmmwWG1eH/4U3w==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/hash": "2.7.0",
-        "@parcel/plugin": "2.7.0",
+        "@parcel/diagnostic": "2.8.0",
+        "@parcel/hash": "2.8.0",
+        "@parcel/plugin": "2.8.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.10.1",
@@ -1400,7 +1385,7 @@
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.8.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1408,19 +1393,19 @@
       }
     },
     "node_modules/@parcel/transformer-webextension": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-webextension/-/transformer-webextension-2.7.0.tgz",
-      "integrity": "sha512-r7mQJ91oVnL9gMvqURlaq4ru95/685utOc51QaOfSCYjuEbosvPUIDXDRAXFVLea56iLP5nIUsrUGtycE6zsQg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-webextension/-/transformer-webextension-2.8.0.tgz",
+      "integrity": "sha512-pGxATimkO7r8JbSysDD45YMmDvk4Tk2AHRQs5mLU/y7QwpT6d8zI30W4+ZpgDqx52Ih5BB2RlaGV1gZeLlpXqg==",
       "dev": true,
       "dependencies": {
         "@mischnic/json-sourcemap": "^0.1.0",
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/diagnostic": "2.8.0",
+        "@parcel/plugin": "2.8.0",
+        "@parcel/utils": "2.8.0",
         "content-security-policy-parser": "^0.3.0"
       },
       "engines": {
-        "parcel": "^2.7.0"
+        "parcel": "^2.8.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1428,32 +1413,32 @@
       }
     },
     "node_modules/@parcel/types": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.7.0.tgz",
-      "integrity": "sha512-+dhXVUnseTCpJvBTGMp0V6X13z6O/A/+CUtwEpMGZ8XSmZ4Gk44GvaTiBOp0bJpWG4fvCKp+UmC8PYbrDiiziw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.8.0.tgz",
+      "integrity": "sha512-DeN3vCnVl9onjtyWxpbP7LwRslVEko4kBaM7yILsuQjEnXmaIOsqIf6FQJOUOPBtQTFFNeQQ2qyf5XoO/rkJ8g==",
       "dev": true,
       "dependencies": {
-        "@parcel/cache": "2.7.0",
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/fs": "2.7.0",
-        "@parcel/package-manager": "2.7.0",
-        "@parcel/source-map": "^2.0.0",
-        "@parcel/workers": "2.7.0",
+        "@parcel/cache": "2.8.0",
+        "@parcel/diagnostic": "2.8.0",
+        "@parcel/fs": "2.8.0",
+        "@parcel/package-manager": "2.8.0",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/workers": "2.8.0",
         "utility-types": "^3.10.0"
       }
     },
     "node_modules/@parcel/utils": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.7.0.tgz",
-      "integrity": "sha512-jNZ5bIGg1r1RDRKi562o4kuVwnz+XJ2Ie3b0Zwrqwvgfj6AbRFIKzDd+h85dWWmcDYzKUbHp11u6VJl1u8Vapg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.0.tgz",
+      "integrity": "sha512-r4ACsGtW7zkMUIgwQyOVtPAFiy8L81gbz4tMIRSqyQKnkW7oEHcQ3uN1/LPxj2yfkyQLmhJxmtptLUy9j53rcw==",
       "dev": true,
       "dependencies": {
-        "@parcel/codeframe": "2.7.0",
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/hash": "2.7.0",
-        "@parcel/logger": "2.7.0",
-        "@parcel/markdown-ansi": "2.7.0",
-        "@parcel/source-map": "^2.0.0",
+        "@parcel/codeframe": "2.8.0",
+        "@parcel/diagnostic": "2.8.0",
+        "@parcel/hash": "2.8.0",
+        "@parcel/logger": "2.8.0",
+        "@parcel/markdown-ansi": "2.8.0",
+        "@parcel/source-map": "^2.1.1",
         "chalk": "^4.1.0"
       },
       "engines": {
@@ -1465,9 +1450,9 @@
       }
     },
     "node_modules/@parcel/watcher": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.0.5.tgz",
-      "integrity": "sha512-x0hUbjv891omnkcHD7ZOhiyyUqUUR6MNjq89JhEI3BxppeKWAm6NPQsqqRrAkCJBogdT/o/My21sXtTI9rJIsw==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.0.7.tgz",
+      "integrity": "sha512-gc3hoS6e+2XdIQ4HHljDB1l0Yx2EWh/sBBtCEFNKGSMlwASWeAQsOY/fPbxOBcZ/pg0jBh4Ga+4xHlZc4faAEQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -1483,15 +1468,15 @@
       }
     },
     "node_modules/@parcel/workers": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.7.0.tgz",
-      "integrity": "sha512-99VfaOX+89+RaoTSyH9ZQtkMBFZBFMvJmVJ/GeJT6QCd2wtKBStTHlaSnQOkLD/iRjJCNwV2xpZmm8YkTwV+hg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.8.0.tgz",
+      "integrity": "sha512-vAzoC/wPHLQnyy9P/TrSPftY8F3MhZqPTFi681mxVtLWA3t7wiNlw1zDVKRDP8m5XS1yQOr8Q56CAHyRexhc8g==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/logger": "2.7.0",
-        "@parcel/types": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/diagnostic": "2.8.0",
+        "@parcel/logger": "2.8.0",
+        "@parcel/types": "2.8.0",
+        "@parcel/utils": "2.8.0",
         "chrome-trace-event": "^1.0.2",
         "nullthrows": "^1.1.1"
       },
@@ -1503,13 +1488,13 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.7.0"
+        "@parcel/core": "^2.8.0"
       }
     },
     "node_modules/@swc/helpers": {
-      "version": "0.4.12",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.12.tgz",
-      "integrity": "sha512-R6RmwS9Dld5lNvwKlPn62+piU+WDG1sMfsnfJioXCciyko/gZ0DQ4Mqglhq1iGU1nQ/RcGkAwfMH+elMSkJH3Q==",
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz",
+      "integrity": "sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.4.0"
@@ -1543,9 +1528,9 @@
       "dev": true
     },
     "node_modules/acorn": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+      "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -1628,9 +1613,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001418",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001418.tgz",
-      "integrity": "sha512-oIs7+JL3K9JRQ3jPZjlH6qyYDp+nBTCais7hjh0s+fuBwufc7uZ7hPYMXrDOJhV360KGMTcczMRObk0/iMqZRg==",
+      "version": "1.0.30001434",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001434.tgz",
+      "integrity": "sha512-aOBHrLmTQw//WFa2rcF1If9fa3ypkC1wzqqiKHgfdrXTWcU8C4gKVZT77eQAPWN1APys3+uQ0Df07rKauXGEYA==",
       "dev": true,
       "funding": [
         {
@@ -1714,9 +1699,9 @@
       }
     },
     "node_modules/cosmiconfig": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
-      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
       "dev": true,
       "dependencies": {
         "@types/parse-json": "^4.0.0",
@@ -1874,9 +1859,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.277",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.277.tgz",
-      "integrity": "sha512-Ej4VyUfGdVY5D2J5WHAVNqrEFBKgeNcX7p/bBQU4x/VKwvnyEvGd62NEkIK3lykLEe9Cg4MCcoWAa+u97o0u/A==",
+      "version": "1.4.284",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
+      "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
       "dev": true
     },
     "node_modules/entities": {
@@ -1928,9 +1913,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.17.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
-      "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
+      "version": "13.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.18.0.tgz",
+      "integrity": "sha512-/mR4KI8Ps2spmoc0Ulu9L7agOF0du1CZNQ3dke8yItYlyKNmGrkONemBbd6V8UTc1Wgcqn21t3WYB7dbRmh6/A==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -1952,9 +1937,9 @@
       }
     },
     "node_modules/htmlnano": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/htmlnano/-/htmlnano-2.0.2.tgz",
-      "integrity": "sha512-+ZrQFS4Ub+zd+/fWwfvoYCEGNEa0/zrpys6CyXxvZDwtL7Pl+pOtRkiujyvBQ7Lmfp7/iEPxtOFgxWA16Gkj3w==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/htmlnano/-/htmlnano-2.0.3.tgz",
+      "integrity": "sha512-S4PGGj9RbdgW8LhbILNK7W9JhmYP8zmDY7KDV/8eCiJBQJlbmltp5I0gv8c5ntLljfdxxfmJ+UJVSqyH4mb41A==",
       "dev": true,
       "dependencies": {
         "cosmiconfig": "^7.0.1",
@@ -1964,9 +1949,9 @@
       "peerDependencies": {
         "cssnano": "^5.0.11",
         "postcss": "^8.3.11",
-        "purgecss": "^4.0.3",
+        "purgecss": "^5.0.0",
         "relateurl": "^0.2.7",
-        "srcset": "^5.0.0",
+        "srcset": "4.0.0",
         "svgo": "^2.8.0",
         "terser": "^5.10.0",
         "uncss": "^0.17.3"
@@ -2097,9 +2082,9 @@
       }
     },
     "node_modules/lightningcss": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.16.0.tgz",
-      "integrity": "sha512-5+ZS9h+xeADcJTF2oRCT3yNZBlDYyOgQSdrWNBCqsIwm8ucKbF061OBVv/WHP4Zk8FToNhwFklk/hMuOngqsIg==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.16.1.tgz",
+      "integrity": "sha512-zU8OTaps3VAodmI2MopfqqOQQ4A9L/2Eo7xoTH/4fNkecy6ftfiGwbbRMTQqtIqJjRg3f927e+lnyBBPhucY1Q==",
       "dev": true,
       "dependencies": {
         "detect-libc": "^1.0.3"
@@ -2112,20 +2097,20 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-darwin-arm64": "1.16.0",
-        "lightningcss-darwin-x64": "1.16.0",
-        "lightningcss-linux-arm-gnueabihf": "1.16.0",
-        "lightningcss-linux-arm64-gnu": "1.16.0",
-        "lightningcss-linux-arm64-musl": "1.16.0",
-        "lightningcss-linux-x64-gnu": "1.16.0",
-        "lightningcss-linux-x64-musl": "1.16.0",
-        "lightningcss-win32-x64-msvc": "1.16.0"
+        "lightningcss-darwin-arm64": "1.16.1",
+        "lightningcss-darwin-x64": "1.16.1",
+        "lightningcss-linux-arm-gnueabihf": "1.16.1",
+        "lightningcss-linux-arm64-gnu": "1.16.1",
+        "lightningcss-linux-arm64-musl": "1.16.1",
+        "lightningcss-linux-x64-gnu": "1.16.1",
+        "lightningcss-linux-x64-musl": "1.16.1",
+        "lightningcss-win32-x64-msvc": "1.16.1"
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.16.0.tgz",
-      "integrity": "sha512-gIhz6eZFwsC4oVMjBGQ3QWDdLQY7vcXFyM/x91PilgHqu63B9uBa10EZA75YoTEkbKhoz0uDCqyHh/EoF1GrkQ==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.16.1.tgz",
+      "integrity": "sha512-/J898YSAiGVqdybHdIF3Ao0Hbh2vyVVj5YNm3NznVzTSvkOi3qQCAtO97sfmNz+bSRHXga7ZPLm+89PpOM5gAg==",
       "cpu": [
         "arm64"
       ],
@@ -2143,9 +2128,9 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.16.0.tgz",
-      "integrity": "sha512-kLPi+OEpDj3UGY6DC8TfjbcULJDKMP+TVKSlrEkNGn8t1YRzi2g4oy7UVTSB5AnSbT0CusUItzdVjHQ49EdoNA==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.16.1.tgz",
+      "integrity": "sha512-vyKCNPRNRqke+5i078V+N0GLfMVLEaNcqIcv28hA/vUNRGk/90EDkDB9EndGay0MoPIrC2y0qE3Y74b/OyedqQ==",
       "cpu": [
         "x64"
       ],
@@ -2163,9 +2148,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.16.0.tgz",
-      "integrity": "sha512-oSwEbvXUPr//H/ainBRJXTxHerlheee/KgkTTmAQWiVnt8HV+bRohTBWWPBy5ZArgiGLwj7ogv45istgljPN2Q==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.16.1.tgz",
+      "integrity": "sha512-0AJC52l40VbrzkMJz6qRvlqVVGykkR2MgRS4bLjVC2ab0H0I/n4p6uPZXGvNIt5gw1PedeND/hq+BghNdgfuPQ==",
       "cpu": [
         "arm"
       ],
@@ -2183,9 +2168,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.16.0.tgz",
-      "integrity": "sha512-Drq9BSVIvmV9zsDJbCZWCulMvKMQWFIlYXPCKV/iwRj+ZAJ1BRngma0cNHB6uW7Wac8Jg04CJN5IA4ELE3J+cQ==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.16.1.tgz",
+      "integrity": "sha512-NqxYXsRvI3/Fb9AQLXKrYsU0Q61LqKz5It+Es9gidsfcw1lamny4lmlUgO3quisivkaLCxEkogaizcU6QeZeWQ==",
       "cpu": [
         "arm64"
       ],
@@ -2203,9 +2188,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.16.0.tgz",
-      "integrity": "sha512-1QXWStnTEo4RFQf0mfGhRyNUeEHilCZ0NA97XgwKwrYr/M7sYKU/1HWY00dPxFJ6GITR2pfJGo9xi3ScSSBxbA==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.16.1.tgz",
+      "integrity": "sha512-VUPQ4dmB9yDQxpJF8/imtwNcbIPzlL6ArLHSUInOGxipDk1lOAklhUjbKUvlL3HVlDwD3WHCxggAY01WpFcjiA==",
       "cpu": [
         "arm64"
       ],
@@ -2223,9 +2208,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.16.0.tgz",
-      "integrity": "sha512-gD2eQYD5OFs1p83R0TcMCEc5HRyJES4lR4THmclv7khm3dc9vc+2VT0kFBPxO1L2AwlZuvXaaMan7X1Ul7uSfA==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.16.1.tgz",
+      "integrity": "sha512-A40Jjnbellnvh4YF+kt047GLnUU59iLN2LFRCyWQG+QqQZeXOCzXfTQ6EJB4yvHB1mQvWOVdAzVrtEmRw3Vh8g==",
       "cpu": [
         "x64"
       ],
@@ -2243,9 +2228,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.16.0.tgz",
-      "integrity": "sha512-HJsKeYxloEvg2WCQhtYPqzZUliLu9JBJNeI5y9cPQeDR/7ayGGLbVhJaotPtzJkElOFL/SaXsS+FRuH4w+yafg==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.16.1.tgz",
+      "integrity": "sha512-VZf76GxW+8mk238tpw0u9R66gBi/m0YB0TvD54oeGiOqvTZ/mabkBkbsuXTSWcKYj8DSrLW+A42qu+6PLRsIgA==",
       "cpu": [
         "x64"
       ],
@@ -2263,9 +2248,9 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.16.0.tgz",
-      "integrity": "sha512-h4ayyAlOMLUHV9NdofcIu79aEjmly93adVxcg5wDJpkvMiwDTufEN30M8G4gGcjo1JE5jFjAcyQcRpXYkYcemA==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.16.1.tgz",
+      "integrity": "sha512-Djy+UzlTtJMayVJU3eFuUW5Gdo+zVTNPJhlYw25tNC9HAoMCkIdSDDrGsWEdEyibEV7xwB8ySTmLuxilfhBtgg==",
       "cpu": [
         "x64"
       ],
@@ -2323,18 +2308,18 @@
       "dev": true
     },
     "node_modules/msgpackr": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.7.2.tgz",
-      "integrity": "sha512-mWScyHTtG6TjivXX9vfIy2nBtRupaiAj0HQ2mtmpmYujAmqZmaaEVPaSZ1NKLMvicaMLFzEaMk0ManxMRg8rMQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.8.0.tgz",
+      "integrity": "sha512-1Cos3r86XACdjLVY4CN8r72Cgs5lUzxSON6yb81sNZP9vC9nnBrEbu1/ldBhuR9BKejtoYV5C9UhmYUvZFJSNQ==",
       "dev": true,
       "optionalDependencies": {
-        "msgpackr-extract": "^2.1.2"
+        "msgpackr-extract": "^2.2.0"
       }
     },
     "node_modules/msgpackr-extract": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-2.1.2.tgz",
-      "integrity": "sha512-cmrmERQFb19NX2JABOGtrKdHMyI6RUyceaPBQ2iRz9GnDkjBWFjNJC0jyyoOfZl2U/LZE3tQCCQc4dlRyA8mcA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-2.2.0.tgz",
+      "integrity": "sha512-0YcvWSv7ZOGl9Od6Y5iJ3XnPww8O7WLcpYMDwX+PAA/uXLDtyw94PJv9GLQV/nnp3cWlDhMoyKZIQLrx33sWog==",
       "dev": true,
       "hasInstallScript": true,
       "optional": true,
@@ -2345,12 +2330,12 @@
         "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
       },
       "optionalDependencies": {
-        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "2.1.2",
-        "@msgpackr-extract/msgpackr-extract-darwin-x64": "2.1.2",
-        "@msgpackr-extract/msgpackr-extract-linux-arm": "2.1.2",
-        "@msgpackr-extract/msgpackr-extract-linux-arm64": "2.1.2",
-        "@msgpackr-extract/msgpackr-extract-linux-x64": "2.1.2",
-        "@msgpackr-extract/msgpackr-extract-win32-x64": "2.1.2"
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "2.2.0",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "2.2.0",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "2.2.0",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "2.2.0",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "2.2.0",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "2.2.0"
       }
     },
     "node_modules/netmask": {
@@ -2420,21 +2405,21 @@
       "dev": true
     },
     "node_modules/parcel": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.7.0.tgz",
-      "integrity": "sha512-pRYwnivwtNP0tip8xYSo4zCB0XhLt7/gJzP1p8OovCqkmFjG9VG+GW9TcAKqMIo0ovEa9tT+/s6gY1Qy+BONGQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.8.0.tgz",
+      "integrity": "sha512-p7Fo75CeMw5HC1luovYpBjzPbAJv/Gn7lxcs4f0LxcwBCWbkQ73zHgJXJQqnM38qQABEYEiQq6000+j+k5U/Mw==",
       "dev": true,
       "dependencies": {
-        "@parcel/config-default": "2.7.0",
-        "@parcel/core": "2.7.0",
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/events": "2.7.0",
-        "@parcel/fs": "2.7.0",
-        "@parcel/logger": "2.7.0",
-        "@parcel/package-manager": "2.7.0",
-        "@parcel/reporter-cli": "2.7.0",
-        "@parcel/reporter-dev-server": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/config-default": "2.8.0",
+        "@parcel/core": "2.8.0",
+        "@parcel/diagnostic": "2.8.0",
+        "@parcel/events": "2.8.0",
+        "@parcel/fs": "2.8.0",
+        "@parcel/logger": "2.8.0",
+        "@parcel/package-manager": "2.8.0",
+        "@parcel/reporter-cli": "2.8.0",
+        "@parcel/reporter-dev-server": "2.8.0",
+        "@parcel/utils": "2.8.0",
         "chalk": "^4.1.0",
         "commander": "^7.0.0",
         "get-port": "^4.2.0",
@@ -2552,9 +2537,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.0.tgz",
+      "integrity": "sha512-9Lmg8hTFZKG0Asr/kW9Bp8tJjRVluO8EJQVfY2T7FMw9T5jy4I/Uvx0Rca/XWf50QQ1/SS48+6IJWnrb+2yemA==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -2593,9 +2578,9 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
       "dev": true
     },
     "node_modules/resolve-from": {
@@ -2708,9 +2693,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.15.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.1.tgz",
-      "integrity": "sha512-K1faMUvpm/FBxjBXud0LWVAGxmvoPbZbfTCYbSgaaYQaIXI3/TdI7a7ZGA73Zrou6Q8Zmz3oeUTsp/dj+ag2Xw==",
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.0.tgz",
+      "integrity": "sha512-KjTV81QKStSfwbNiwlBXfcgMcOloyuRdb62/iLFPGBcVNF4EXjhdYBhYHmbJpiBrVxZhDvltE11j+LBQUxEEJg==",
       "dev": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.2",
@@ -2738,9 +2723,9 @@
       "dev": true
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
       "dev": true
     },
     "node_modules/type-fest": {
@@ -2756,9 +2741,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
+      "integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -2956,9 +2941,9 @@
       "dev": true
     },
     "@jridgewell/trace-mapping": {
-      "version": "0.3.16",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.16.tgz",
-      "integrity": "sha512-LCQ+NeThyJ4k1W2d+vIKdxuSt9R3pQSZ4P92m7EakaYuXcVWbHuT5bjNcqLd4Rdgi6xYWYDvBJZJLZSLanjDcA==",
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
+      "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
       "dev": true,
       "requires": {
         "@jridgewell/resolve-uri": "3.1.0",
@@ -3034,161 +3019,162 @@
       }
     },
     "@msgpackr-extract/msgpackr-extract-darwin-arm64": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-2.1.2.tgz",
-      "integrity": "sha512-TyVLn3S/+ikMDsh0gbKv2YydKClN8HaJDDpONlaZR+LVJmsxLFUgA+O7zu59h9+f9gX1aj/ahw9wqa6rosmrYQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-2.2.0.tgz",
+      "integrity": "sha512-Z9LFPzfoJi4mflGWV+rv7o7ZbMU5oAU9VmzCgL240KnqDW65Y2HFCT3MW06/ITJSnbVLacmcEJA8phywK7JinQ==",
       "dev": true,
       "optional": true
     },
     "@msgpackr-extract/msgpackr-extract-darwin-x64": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-2.1.2.tgz",
-      "integrity": "sha512-YPXtcVkhmVNoMGlqp81ZHW4dMxK09msWgnxtsDpSiZwTzUBG2N+No2bsr7WMtBKCVJMSD6mbAl7YhKUqkp/Few==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-2.2.0.tgz",
+      "integrity": "sha512-vq0tT8sjZsy4JdSqmadWVw6f66UXqUCabLmUVHZwUFzMgtgoIIQjT4VVRHKvlof3P/dMCkbMJ5hB1oJ9OWHaaw==",
       "dev": true,
       "optional": true
     },
     "@msgpackr-extract/msgpackr-extract-linux-arm": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-2.1.2.tgz",
-      "integrity": "sha512-42R4MAFeIeNn+L98qwxAt360bwzX2Kf0ZQkBBucJ2Ircza3asoY4CDbgiu9VWklq8gWJVSJSJBwDI+c/THiWkA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-2.2.0.tgz",
+      "integrity": "sha512-SaJ3Qq4lX9Syd2xEo9u3qPxi/OB+5JO/ngJKK97XDpa1C587H9EWYO6KD8995DAjSinWvdHKRrCOXVUC5fvGOg==",
       "dev": true,
       "optional": true
     },
     "@msgpackr-extract/msgpackr-extract-linux-arm64": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-2.1.2.tgz",
-      "integrity": "sha512-vHZ2JiOWF2+DN9lzltGbhtQNzDo8fKFGrf37UJrgqxU0yvtERrzUugnfnX1wmVfFhSsF8OxrfqiNOUc5hko1Zg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-2.2.0.tgz",
+      "integrity": "sha512-hlxxLdRmPyq16QCutUtP8Tm6RDWcyaLsRssaHROatgnkOxdleMTgetf9JsdncL8vLh7FVy/RN9i3XR5dnb9cRA==",
       "dev": true,
       "optional": true
     },
     "@msgpackr-extract/msgpackr-extract-linux-x64": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-2.1.2.tgz",
-      "integrity": "sha512-RjRoRxg7Q3kPAdUSC5EUUPlwfMkIVhmaRTIe+cqHbKrGZ4M6TyCA/b5qMaukQ/1CHWrqYY2FbKOAU8Hg0pQFzg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-2.2.0.tgz",
+      "integrity": "sha512-94y5PJrSOqUNcFKmOl7z319FelCLAE0rz/jPCWS+UtdMZvpa4jrQd+cJPQCLp2Fes1yAW/YUQj/Di6YVT3c3Iw==",
       "dev": true,
       "optional": true
     },
     "@msgpackr-extract/msgpackr-extract-win32-x64": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-2.1.2.tgz",
-      "integrity": "sha512-rIZVR48zA8hGkHIK7ED6+ZiXsjRCcAVBJbm8o89OKAMTmEAQ2QvoOxoiu3w2isAaWwzgtQIOFIqHwvZDyLKCvw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-2.2.0.tgz",
+      "integrity": "sha512-XrC0JzsqQSvOyM3t04FMLO6z5gCuhPE6k4FXuLK5xf52ZbdvcFe1yBmo7meCew9B8G2f0T9iu9t3kfTYRYROgA==",
       "dev": true,
       "optional": true
     },
     "@parcel/bundler-default": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.7.0.tgz",
-      "integrity": "sha512-PU5MtWWhc+dYI9x8mguYnm9yiG6TkI7niRpxgJgtqAyGHuEyNXVBQQ0X+qyOF4D9LdankBf8uNN18g31IET2Zg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.8.0.tgz",
+      "integrity": "sha512-OvDDhxX4LwfGe7lYVMbJMzqNcDk8ydOqNw0Hra9WPgl0m5gju/eVIbDvot3JXp5F96FmV36uCxdODJhKTNoAzQ==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/hash": "2.7.0",
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/diagnostic": "2.8.0",
+        "@parcel/graph": "2.8.0",
+        "@parcel/hash": "2.8.0",
+        "@parcel/plugin": "2.8.0",
+        "@parcel/utils": "2.8.0",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/cache": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.7.0.tgz",
-      "integrity": "sha512-JlXNoZXcWzLKdDlfeF3dIj5Vtel5T9vtdBN72PJ+cjC4qNHk4Uwvc5sfOBELuibGN0bVu2bwY9nUgSwCiB1iIA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.8.0.tgz",
+      "integrity": "sha512-k945hrafMDR2wyCKyZYgwypeLLuZWce6FzhgunI4taBUeVnNCcpFAWzbfOVQ39SqZTGDqG3MNT+VuehssHXxyg==",
       "dev": true,
       "requires": {
-        "@parcel/fs": "2.7.0",
-        "@parcel/logger": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/fs": "2.8.0",
+        "@parcel/logger": "2.8.0",
+        "@parcel/utils": "2.8.0",
         "lmdb": "2.5.2"
       }
     },
     "@parcel/codeframe": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.7.0.tgz",
-      "integrity": "sha512-UTKx0jejJmmO1dwTHSJuRgrO8N6PMlkxRT6sew8N6NC3Bgv6pu0EbO+RtlWt/jCvzcdLOPdIoTzj4MMZvgcMYg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.8.0.tgz",
+      "integrity": "sha512-821d+KVcpEvJNMj9WMC39xXZK6zvRS/HUjQag2f3DkcRcZwk1uXJZdW6p1EB7C3e4e/0KSK3NTSVGEvbOSR+9w==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0"
       }
     },
     "@parcel/compressor-raw": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.7.0.tgz",
-      "integrity": "sha512-SCXwnOOQT6EmpusBsYWNQ/RFri+2JnKuE0gMSf2dROl2xbererX45FYzeDplWALCKAdjMNDpFwU+FyMYoVZSCQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.8.0.tgz",
+      "integrity": "sha512-tM49t0gDQnwJbrDCeoCn9LRc8inZ/TSPQTttJTfcmFHHFqEllI0ZDVG0AiQw5NOMQbBLYiKun1adXn8pkcPLEA==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.7.0"
+        "@parcel/plugin": "2.8.0"
       }
     },
     "@parcel/config-default": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.7.0.tgz",
-      "integrity": "sha512-ZzsLr97AYrz8c9k6qn3DlqPzifi3vbP7q3ynUrAFxmt0L4+K0H9N508ZkORYmCgaFjLIQ8Y3eWpwCJ0AewPNIg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.8.0.tgz",
+      "integrity": "sha512-j9g50QNSLjuNpY0TP01EgGJPxWNes9d+e8+N07Z5Wv0u+UUnJ2uIOpo7PVn7ullOGhm1f9lP4KsJenu5gWb+cg==",
       "dev": true,
       "requires": {
-        "@parcel/bundler-default": "2.7.0",
-        "@parcel/compressor-raw": "2.7.0",
-        "@parcel/namer-default": "2.7.0",
-        "@parcel/optimizer-css": "2.7.0",
-        "@parcel/optimizer-htmlnano": "2.7.0",
-        "@parcel/optimizer-image": "2.7.0",
-        "@parcel/optimizer-svgo": "2.7.0",
-        "@parcel/optimizer-terser": "2.7.0",
-        "@parcel/packager-css": "2.7.0",
-        "@parcel/packager-html": "2.7.0",
-        "@parcel/packager-js": "2.7.0",
-        "@parcel/packager-raw": "2.7.0",
-        "@parcel/packager-svg": "2.7.0",
-        "@parcel/reporter-dev-server": "2.7.0",
-        "@parcel/resolver-default": "2.7.0",
-        "@parcel/runtime-browser-hmr": "2.7.0",
-        "@parcel/runtime-js": "2.7.0",
-        "@parcel/runtime-react-refresh": "2.7.0",
-        "@parcel/runtime-service-worker": "2.7.0",
-        "@parcel/transformer-babel": "2.7.0",
-        "@parcel/transformer-css": "2.7.0",
-        "@parcel/transformer-html": "2.7.0",
-        "@parcel/transformer-image": "2.7.0",
-        "@parcel/transformer-js": "2.7.0",
-        "@parcel/transformer-json": "2.7.0",
-        "@parcel/transformer-postcss": "2.7.0",
-        "@parcel/transformer-posthtml": "2.7.0",
-        "@parcel/transformer-raw": "2.7.0",
-        "@parcel/transformer-react-refresh-wrap": "2.7.0",
-        "@parcel/transformer-svg": "2.7.0"
+        "@parcel/bundler-default": "2.8.0",
+        "@parcel/compressor-raw": "2.8.0",
+        "@parcel/namer-default": "2.8.0",
+        "@parcel/optimizer-css": "2.8.0",
+        "@parcel/optimizer-htmlnano": "2.8.0",
+        "@parcel/optimizer-image": "2.8.0",
+        "@parcel/optimizer-svgo": "2.8.0",
+        "@parcel/optimizer-terser": "2.8.0",
+        "@parcel/packager-css": "2.8.0",
+        "@parcel/packager-html": "2.8.0",
+        "@parcel/packager-js": "2.8.0",
+        "@parcel/packager-raw": "2.8.0",
+        "@parcel/packager-svg": "2.8.0",
+        "@parcel/reporter-dev-server": "2.8.0",
+        "@parcel/resolver-default": "2.8.0",
+        "@parcel/runtime-browser-hmr": "2.8.0",
+        "@parcel/runtime-js": "2.8.0",
+        "@parcel/runtime-react-refresh": "2.8.0",
+        "@parcel/runtime-service-worker": "2.8.0",
+        "@parcel/transformer-babel": "2.8.0",
+        "@parcel/transformer-css": "2.8.0",
+        "@parcel/transformer-html": "2.8.0",
+        "@parcel/transformer-image": "2.8.0",
+        "@parcel/transformer-js": "2.8.0",
+        "@parcel/transformer-json": "2.8.0",
+        "@parcel/transformer-postcss": "2.8.0",
+        "@parcel/transformer-posthtml": "2.8.0",
+        "@parcel/transformer-raw": "2.8.0",
+        "@parcel/transformer-react-refresh-wrap": "2.8.0",
+        "@parcel/transformer-svg": "2.8.0"
       }
     },
     "@parcel/config-webextension": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/config-webextension/-/config-webextension-2.7.0.tgz",
-      "integrity": "sha512-5OBhrRfsamI5oInv2APMgz9+qSqDhb07iR98qhRMYt2S34/Npj08vrUtqr2nZiiA5ypThT+FRtRjYAtiHPQMSQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/config-webextension/-/config-webextension-2.8.0.tgz",
+      "integrity": "sha512-80gtgNU77kT1DY9SXNt8CwBgHLu5qWwmo0sw2SCMzg+iXYSj8WAuESAN56O6J+Su3IWs+IzF6MdCAYFTyGM5mA==",
       "dev": true,
       "requires": {
-        "@parcel/config-default": "2.7.0",
-        "@parcel/packager-webextension": "2.7.0",
-        "@parcel/runtime-webextension": "2.7.0",
-        "@parcel/transformer-raw": "2.7.0",
-        "@parcel/transformer-webextension": "2.7.0"
+        "@parcel/config-default": "2.8.0",
+        "@parcel/packager-webextension": "2.8.0",
+        "@parcel/runtime-webextension": "2.8.0",
+        "@parcel/transformer-raw": "2.8.0",
+        "@parcel/transformer-webextension": "2.8.0"
       }
     },
     "@parcel/core": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.7.0.tgz",
-      "integrity": "sha512-7yKZUdh314Q/kU/9+27ZYTfcnXS6VYHuG+iiUlIohnvUUybxLqVJhdMU9Q+z2QcPka1IdJWz4K4Xx0y6/4goyg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.8.0.tgz",
+      "integrity": "sha512-udzbe3jjbpfKlRE9pdlROAa+lvAjS1L/AzN6r2j1y/Fsn7ze/NfvnCFw6o2YNIrXg002aQ7M1St/x1fdGfmVKA==",
       "dev": true,
       "requires": {
         "@mischnic/json-sourcemap": "^0.1.0",
-        "@parcel/cache": "2.7.0",
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/events": "2.7.0",
-        "@parcel/fs": "2.7.0",
-        "@parcel/graph": "2.7.0",
-        "@parcel/hash": "2.7.0",
-        "@parcel/logger": "2.7.0",
-        "@parcel/package-manager": "2.7.0",
-        "@parcel/plugin": "2.7.0",
-        "@parcel/source-map": "^2.0.0",
-        "@parcel/types": "2.7.0",
-        "@parcel/utils": "2.7.0",
-        "@parcel/workers": "2.7.0",
+        "@parcel/cache": "2.8.0",
+        "@parcel/diagnostic": "2.8.0",
+        "@parcel/events": "2.8.0",
+        "@parcel/fs": "2.8.0",
+        "@parcel/graph": "2.8.0",
+        "@parcel/hash": "2.8.0",
+        "@parcel/logger": "2.8.0",
+        "@parcel/package-manager": "2.8.0",
+        "@parcel/plugin": "2.8.0",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/types": "2.8.0",
+        "@parcel/utils": "2.8.0",
+        "@parcel/workers": "2.8.0",
         "abortcontroller-polyfill": "^1.1.9",
         "base-x": "^3.0.8",
         "browserslist": "^4.6.6",
@@ -3201,19 +3187,10 @@
         "semver": "^5.7.1"
       }
     },
-    "@parcel/css": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@parcel/css/-/css-1.14.0.tgz",
-      "integrity": "sha512-r5tJWe6NF6lesfPw1N3g7N7WUKpHqi2ONnw9wl5ccSGGIxkmgcPaPQxfvmhdjXvQnktSuIOR0HjQXVXu+/en/w==",
-      "dev": true,
-      "requires": {
-        "lightningcss": "^1.14.0"
-      }
-    },
     "@parcel/diagnostic": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.7.0.tgz",
-      "integrity": "sha512-pdq/cTwVoL0n8yuDCRXFRSQHVWdmmIXPt3R3iT4KtYDYvOrMT2dLPT79IMqQkhYPANW8GuL15n/WxRngfRdkug==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.8.0.tgz",
+      "integrity": "sha512-ERnk0zDvm0jQUSj1M+2PLiwVC6nWrtuFEuye6VGuxRDcp9NHbz6gwApeEYxFkPsb3TQPhNjnXXm5nmAw1bpWWw==",
       "dev": true,
       "requires": {
         "@mischnic/json-sourcemap": "^0.1.0",
@@ -3221,47 +3198,47 @@
       }
     },
     "@parcel/events": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.7.0.tgz",
-      "integrity": "sha512-kQDwMKgZ1U4M/G17qeDYF6bW5kybluN6ajYPc7mZcrWg+trEI/oXi81GMFaMX0BSUhwhbiN5+/Vb2wiG/Sn6ig==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.8.0.tgz",
+      "integrity": "sha512-xqSZYY3oONM4IZm9+vhyFqX+KFIl145veIczUikwGJlcJZQfAAw736syPx6ecpB+m1EVg3AlvJWy7Lmel4Ak+Q==",
       "dev": true
     },
     "@parcel/fs": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.7.0.tgz",
-      "integrity": "sha512-PU5fo4Hh8y03LZgemgVREttc0wyHQUNmsJCybxTB7EjJie2CqJRumo+DFppArlvdchLwJdc9em03yQV/GNWrEg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.8.0.tgz",
+      "integrity": "sha512-v3DbJlpl8v2/VRlZPw7cy+0myi0YfLblGZcwDvqIsWS35qyxD2rmtYV8u1BusonbgmJeaKiopSECmJkumt0jCw==",
       "dev": true,
       "requires": {
-        "@parcel/fs-search": "2.7.0",
-        "@parcel/types": "2.7.0",
-        "@parcel/utils": "2.7.0",
-        "@parcel/watcher": "^2.0.0",
-        "@parcel/workers": "2.7.0"
+        "@parcel/fs-search": "2.8.0",
+        "@parcel/types": "2.8.0",
+        "@parcel/utils": "2.8.0",
+        "@parcel/watcher": "^2.0.7",
+        "@parcel/workers": "2.8.0"
       }
     },
     "@parcel/fs-search": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/fs-search/-/fs-search-2.7.0.tgz",
-      "integrity": "sha512-K1Hv25bnRpwQVA15RvcRuB8ZhfclnCHA8N8L6w7Ul1ncSJDxCIkIAc5hAubYNNYW3kWjCC2SOaEgFKnbvMllEQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/fs-search/-/fs-search-2.8.0.tgz",
+      "integrity": "sha512-yo7/Y8DCFlhOlIBb5SsRDTkM+7g0DY9sK57iw3hn2z1tGoIiIRptrieImFYSizs7HfDwDY/PMLfORmUdoReDzQ==",
       "dev": true,
       "requires": {
         "detect-libc": "^1.0.3"
       }
     },
     "@parcel/graph": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-2.7.0.tgz",
-      "integrity": "sha512-Q6E94GS6q45PtsZh+m+gvFRp/N1Qopxhu2sxjcWsGs5iBd6IWn2oYLWOH5iVzEjWuYpW2HkB08lH6J50O63uOA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-2.8.0.tgz",
+      "integrity": "sha512-JvAyvBpGmhZ30bi+hStQr52eu+InfJBoiN9Z/32byIWhXEl02EAOwfsPqAe+FGCsdgXnnCGg5F9ZCqwzZ9dwbw==",
       "dev": true,
       "requires": {
-        "@parcel/utils": "2.7.0",
+        "@parcel/utils": "2.8.0",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/hash": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/hash/-/hash-2.7.0.tgz",
-      "integrity": "sha512-k6bSKnIlPJMPU3yjQzfgfvF9zuJZGOAlJgzpL4BbWvdbE8BTdjzLcFn0Ujrtud94EgIkiXd22sC2HpCUWoHGdA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/hash/-/hash-2.8.0.tgz",
+      "integrity": "sha512-KV1+96t7Nukth5K7ldUXjVr8ZTH9Dohl49K0Tc+5Qkysif0OxwcDtpVDmcnrUnWmqdBX0AdoLY0Q2Nnly89n/w==",
       "dev": true,
       "requires": {
         "detect-libc": "^1.0.3",
@@ -3269,69 +3246,69 @@
       }
     },
     "@parcel/logger": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.7.0.tgz",
-      "integrity": "sha512-qjMY/bYo38+o+OiIrTRldU9CwL1E7J72t+xkTP8QIcUxLWz5LYR0YbynZUVulmBSfqsykjjxCy4a+8siVr+lPw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.0.tgz",
+      "integrity": "sha512-W+7rKsLxLUX6xRmP8PhGWcG48PqrzTPeMWpgSds5nXxAHEFh4cYbkwPKGoTU65a9xUDVyqNreHNIKyizgwAZHQ==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/events": "2.7.0"
+        "@parcel/diagnostic": "2.8.0",
+        "@parcel/events": "2.8.0"
       }
     },
     "@parcel/markdown-ansi": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.7.0.tgz",
-      "integrity": "sha512-ipOX0D6FVZFEXeb/z8MnTMq2RQEIuaILY90olVIuHEFLHHfOPEn+RK3u13HA1ChF5/9E3cMD79tu6x9JL9Kqag==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.8.0.tgz",
+      "integrity": "sha512-xItzXmc3btFhJXsIbE946iaqE6STd2xe5H0zSIaZVXEeucCtMzcd4hxRELquxPstlrAOrrp/lrRpbAlMhso9iA==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0"
       }
     },
     "@parcel/namer-default": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.7.0.tgz",
-      "integrity": "sha512-lIKMdsmi//7fepecNDYmJYzBlL91HifPsX03lJCdu1dC6q5fBs+gG0XjKKG7yPnSCw1qH/4m7drzt9+dRZYAHQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.8.0.tgz",
+      "integrity": "sha512-cVCx2kJA/Bv7O9pVad1UOibaybR/B+QdWV8Ols8HH4lC2gyjLBXEIR0uuPSEbkGwMEcofG6zA3MwsoPa6r5lBg==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/plugin": "2.7.0",
+        "@parcel/diagnostic": "2.8.0",
+        "@parcel/plugin": "2.8.0",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/node-resolver-core": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-2.7.0.tgz",
-      "integrity": "sha512-5UJQHalqMxdhJIs2hhqQzFfQpF7+NAowsRq064lYtiRvcD8wMr3OOQ9wd1iazGpFSl4JKdT7BwDU9/miDJmanQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-2.8.0.tgz",
+      "integrity": "sha512-cECSh08NSRt1csmmMeKxlnO6ZhXRTuRijkHKFa4iG5hPL+3Cu04YGhuK/QWlP5vNCPVrH3ISlhzlPU5fAi/nEg==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/diagnostic": "2.8.0",
+        "@parcel/utils": "2.8.0",
         "nullthrows": "^1.1.1",
         "semver": "^5.7.1"
       }
     },
     "@parcel/optimizer-css": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.7.0.tgz",
-      "integrity": "sha512-IfnOMACqhcAclKyOW9X9JpsknB6OShk9OVvb8EvbDTKHJhQHNNmzE88OkSI/pS3ZVZP9Zj+nWcVHguV+kvDeiQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.8.0.tgz",
+      "integrity": "sha512-T5r3gZVm1xFw6l//iLkzLDUvFzNTUvL5kAtyU5gS5yH/dg7eCS09Km/c2anViQnmXwFUt7zIlBovj1doxAVNSw==",
       "dev": true,
       "requires": {
-        "@parcel/css": "^1.12.2",
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/plugin": "2.7.0",
-        "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/diagnostic": "2.8.0",
+        "@parcel/plugin": "2.8.0",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/utils": "2.8.0",
         "browserslist": "^4.6.6",
+        "lightningcss": "^1.16.1",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/optimizer-htmlnano": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.7.0.tgz",
-      "integrity": "sha512-5QrGdWS5Hi4VXE3nQNrGqugmSXt68YIsWwKRAdarOxzyULSJS3gbCiQOXqIPRJobfZjnSIcdtkyxSiCUe1inIA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.8.0.tgz",
+      "integrity": "sha512-NxEKTRvue/WAU+XbQGfNIU6c7chDekdkwwv9YnCxHEOhnBu4Ok+2tdmCtPuA+4UUNszGxXlaHMnqSrjmqX2S6Q==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.7.0",
+        "@parcel/plugin": "2.8.0",
         "htmlnano": "^2.0.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
@@ -3339,225 +3316,225 @@
       }
     },
     "@parcel/optimizer-image": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.7.0.tgz",
-      "integrity": "sha512-EnaXz5UjR67FUu0BEcqZTT9LsbB/iFAkkghCotbnbOuC5QQsloq6tw54TKU3y+R3qsjgUoMtGxPcGfVoXxZXYw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.8.0.tgz",
+      "integrity": "sha512-66eSoCCGZVRiY6U4OqqYrhQcBcHI9cOkIEbxadZYOF4cJhsskjUDJR0jLb4j2PE6QxUNYlyj5OglQqRLwhz7vA==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0",
-        "@parcel/workers": "2.7.0",
+        "@parcel/diagnostic": "2.8.0",
+        "@parcel/plugin": "2.8.0",
+        "@parcel/utils": "2.8.0",
+        "@parcel/workers": "2.8.0",
         "detect-libc": "^1.0.3"
       }
     },
     "@parcel/optimizer-svgo": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-svgo/-/optimizer-svgo-2.7.0.tgz",
-      "integrity": "sha512-IO1JV4NpfP3V7FrhsqCcV8pDQIHraFi1/ZvEJyssITxjH49Im/txKlwMiQuZZryAPn8Xb8g395Muawuk6AK6sg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-svgo/-/optimizer-svgo-2.8.0.tgz",
+      "integrity": "sha512-qQzM32CzJJuniFaTZDspVn/Vtz/PJ/f89+FckLpWZJVWNihgwTHC1/F0YTDH8g6czNw5ZijwQ3xBVuJQYyIXsQ==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/diagnostic": "2.8.0",
+        "@parcel/plugin": "2.8.0",
+        "@parcel/utils": "2.8.0",
         "svgo": "^2.4.0"
       }
     },
     "@parcel/optimizer-terser": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-terser/-/optimizer-terser-2.7.0.tgz",
-      "integrity": "sha512-07VZjIO8xsl2/WmS/qHI8lI/cpu47iS9eRpqwfZEEsdk1cfz50jhWkmFudHBxiHGMfcZ//1+DdaPg9RDBWZtZA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-terser/-/optimizer-terser-2.8.0.tgz",
+      "integrity": "sha512-slS6GWQ3u418WtJmlqlA5Njljcq4OaEdDDR2ifEwltG8POv+hsvD5AAoM2XB0GJwY97TQtdMbBu2DuDF3yM/1Q==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/plugin": "2.7.0",
-        "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/diagnostic": "2.8.0",
+        "@parcel/plugin": "2.8.0",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/utils": "2.8.0",
         "nullthrows": "^1.1.1",
         "terser": "^5.2.0"
       }
     },
     "@parcel/package-manager": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.7.0.tgz",
-      "integrity": "sha512-wmfSX1mRrTi8MeA4KrnPk/x7zGUsILCQmTo6lA4gygzAxDbM1pGuyFN8/Kt0y0SFO2lbljARtD/4an5qdotH+Q==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.8.0.tgz",
+      "integrity": "sha512-n4FgerAX1lTKKTgxmiocnos47Y+b0L60iwU6Q4cC2n4KQNRuNyfhxFXwWcqHstR9wa72JgPaDgo4k0l3Bk8FZw==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/fs": "2.7.0",
-        "@parcel/logger": "2.7.0",
-        "@parcel/types": "2.7.0",
-        "@parcel/utils": "2.7.0",
-        "@parcel/workers": "2.7.0",
+        "@parcel/diagnostic": "2.8.0",
+        "@parcel/fs": "2.8.0",
+        "@parcel/logger": "2.8.0",
+        "@parcel/types": "2.8.0",
+        "@parcel/utils": "2.8.0",
+        "@parcel/workers": "2.8.0",
         "semver": "^5.7.1"
       }
     },
     "@parcel/packager-css": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.7.0.tgz",
-      "integrity": "sha512-44nzZwu+ssGuiFmYM6cf/Y4iChiUZ4DUzzpegnGlhXtKJKe4NHntxThJynuRZWKN2AAf48avApDpimg2jW0KDw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.8.0.tgz",
+      "integrity": "sha512-tv/Bto0P6fXjqQ9uCZ8/6b/+38Zr/N2MC7/Nbflzww/lp0k2+kkE9MVJJDr5kST/SzTBRrhbDo+yTbtdZikJYg==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/plugin": "2.8.0",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/utils": "2.8.0",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/packager-html": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.7.0.tgz",
-      "integrity": "sha512-Zgqd7sdcY/UnR370GR0q2ilmEohUDXsO8A1F28QCJzIsR1iCB6KRUT74+pawfQ1IhXZLaaFLLYe0UWcfm0JeXg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.8.0.tgz",
+      "integrity": "sha512-4x09v/bt767rxwGTuEw82CjheoOtIKNu4sx1gqwQOz9QowKPniXOIaD+0XmLiARdzRErucf0sL19QHfNcPAhUw==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/types": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/plugin": "2.8.0",
+        "@parcel/types": "2.8.0",
+        "@parcel/utils": "2.8.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5"
       }
     },
     "@parcel/packager-js": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.7.0.tgz",
-      "integrity": "sha512-wTRdM81PgRVDzWGXdWmqLwguWnTYWzhEDdjXpW2n8uMOu/CjHhMtogk65aaYk3GOnq6OBL/NsrmBiV/zKPj1vA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.8.0.tgz",
+      "integrity": "sha512-Tn2EtWM1TEdj4t5pt0QjBDzqrXrfRTL3WsdMipZwDSuX04KS0jedJINHjh46HOMwyfJxLbUg3xkGX7F5mYQj5g==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/hash": "2.7.0",
-        "@parcel/plugin": "2.7.0",
-        "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/diagnostic": "2.8.0",
+        "@parcel/hash": "2.8.0",
+        "@parcel/plugin": "2.8.0",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/utils": "2.8.0",
         "globals": "^13.2.0",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/packager-raw": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.7.0.tgz",
-      "integrity": "sha512-jg2Zp8dI5VpIQlaeahXDCfrPN9m/DKht1NkR9P2CylMAwqCcc1Xc1RRiF0wfwcPZpPMpq1265n+4qnB7rjGBlA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.8.0.tgz",
+      "integrity": "sha512-s3VniER3X2oNTlfytBGIQF+UZFVNLFWuVu1IkZ8Wg6uYQffrExDlbNDcmFCDcfvcejL3Ch5igP+L6N00f6+wAQ==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.7.0"
+        "@parcel/plugin": "2.8.0"
       }
     },
     "@parcel/packager-svg": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.7.0.tgz",
-      "integrity": "sha512-EmJg3HpD6/xxKBjir/CdCKJZwI24iVfBuxRS9LUp3xHAIebOzVh1z6IN+i2Di5+NyRwfOFaLliL4uMa1zwbyCA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.8.0.tgz",
+      "integrity": "sha512-+BSpdPiNjlAne28nOjG2AyiOejAehe/+X9MxL2FIpPP7UBLNc2ekaM0mDTR5iY45YtZa57oyErBT/U6wZ1TCjw==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/types": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/plugin": "2.8.0",
+        "@parcel/types": "2.8.0",
+        "@parcel/utils": "2.8.0",
         "posthtml": "^0.16.4"
       }
     },
     "@parcel/packager-webextension": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-webextension/-/packager-webextension-2.7.0.tgz",
-      "integrity": "sha512-HoGE/6S+beiFuLhYWUctA1UHtN1YIuTeqP3JitDwGEMz2iMaffajTP+8LNGqZjB3X+98rVYiNLdk0uEWUs70kw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-webextension/-/packager-webextension-2.8.0.tgz",
+      "integrity": "sha512-ODB3sTXk/qyivK0JcM+kw9MV5pWigqppIOXQAK5zPv4sYHlMNuZJiANKizs5aP1+9Iz5ludU1wM1qMe1n/xDiw==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/plugin": "2.8.0",
+        "@parcel/utils": "2.8.0",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/plugin": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.7.0.tgz",
-      "integrity": "sha512-qqgx+nnMn6/0lRc4lKbLGmhNtBiT93S2gFNB4Eb4Pfz/SxVYoW+fmml+KdfOSiZffWOAH5L6NwhyD7N8aSikzw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.8.0.tgz",
+      "integrity": "sha512-Tsf+7nDg7KauvTVY6rGc7CmgJruKSwJ54KJ9s5nYFFP9nfwmyqbayCi9xOxicWU9zIHfuF5Etwf17lcA0oAvzw==",
       "dev": true,
       "requires": {
-        "@parcel/types": "2.7.0"
+        "@parcel/types": "2.8.0"
       }
     },
     "@parcel/reporter-cli": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.7.0.tgz",
-      "integrity": "sha512-80gEODg8cnAmnxGVuaSVDo8JJ54P9AA2bHwSs1cIkHWlJ3BjDQb83H31bBHncJ5Kn5kQ/j+7WjlqHpTCiOR9PA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.8.0.tgz",
+      "integrity": "sha512-ea4/Lp+2jDbzb/tfTgUKzYU51FK8wcewDoYNr06uL+wvx/vzYIDG0jHfzaOTasREnm7ECDr1Zu2Iknrgk1STqQ==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/types": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/plugin": "2.8.0",
+        "@parcel/types": "2.8.0",
+        "@parcel/utils": "2.8.0",
         "chalk": "^4.1.0",
         "term-size": "^2.2.1"
       }
     },
     "@parcel/reporter-dev-server": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.7.0.tgz",
-      "integrity": "sha512-ySuou5addK8fGue8aXzo536BaEjMujDrEc1xkp4TasInXHVcA98b+SYX5NAZTGob5CxKvZQ5ylhg77zW30B+iA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.8.0.tgz",
+      "integrity": "sha512-wg6hUrQ8vUmvlP2fg8YEzYndmq7hWZ21ZgBv4So1Z65I+Qav85Uox7bjGLCSJwEAjdjFKfhV9RGULGzqh8vcAQ==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0"
+        "@parcel/plugin": "2.8.0",
+        "@parcel/utils": "2.8.0"
       }
     },
     "@parcel/resolver-default": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.7.0.tgz",
-      "integrity": "sha512-v8TvWsbLK7/q7n4gv6OrYNbW18xUx4zKbVMGZb1u4yMhzEH4HFr1D9OeoTq3jk+ximAigds8B6triQbL5exF7A==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.8.0.tgz",
+      "integrity": "sha512-kO5W+O3Ql6NXNFS6lvfSSt1R+PxO1atNLYxZdVSM6+QQxRMiztfqzZs//RM+oUp+af6muDSUPlNs+RORX0fing==",
       "dev": true,
       "requires": {
-        "@parcel/node-resolver-core": "2.7.0",
-        "@parcel/plugin": "2.7.0"
+        "@parcel/node-resolver-core": "2.8.0",
+        "@parcel/plugin": "2.8.0"
       }
     },
     "@parcel/runtime-browser-hmr": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.7.0.tgz",
-      "integrity": "sha512-PLbMLdclQeYsi2LkilZVGFV1n3y55G1jaBvby4ekedUZjMw3SWdMY2tDxgSDdFWfLCnYHJXdGUQSzGGi1kPzjA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.8.0.tgz",
+      "integrity": "sha512-zV5wGGvm1cDwWAzkwPUaKh6inWYKxq67YWY4G396PXLMxddM9SQC1c7iFM60OPnD4A+BMOLOy7N6//20h15Dlg==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0"
+        "@parcel/plugin": "2.8.0",
+        "@parcel/utils": "2.8.0"
       }
     },
     "@parcel/runtime-js": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.7.0.tgz",
-      "integrity": "sha512-9/YUZTBNrSN2H6rbz/o1EOM0O7I3ZR/x9IDzxjJBD6Mi+0uCgCD02aedare/SNr1qgnbZZWmhpOzC+YgREcfLA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.8.0.tgz",
+      "integrity": "sha512-IwT1rX8ZamoYZv0clfswZemfXcIfk+YXwNsqXwzzh6TaMGagj/ZZl1llkn7ERQFq4EoLEoDGGkxqsrJjBp9NDQ==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/plugin": "2.8.0",
+        "@parcel/utils": "2.8.0",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/runtime-react-refresh": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.7.0.tgz",
-      "integrity": "sha512-vDKO0rWqRzEpmvoZ4kkYUiSsTxT5NnH904BFPFxKI0wJCl6yEmPuEifmATo73OuYhP6jIP3Qfl1R4TtiDFPJ1Q==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.8.0.tgz",
+      "integrity": "sha512-a6uuZWkl+mJur2WLZKmpEqq1P06tvRwqGefYbE26DWpwXwU9dLpfnv/nT0hqCmVDHd2TkMyCffolSmq1vY05ew==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/plugin": "2.8.0",
+        "@parcel/utils": "2.8.0",
         "react-error-overlay": "6.0.9",
         "react-refresh": "^0.9.0"
       }
     },
     "@parcel/runtime-service-worker": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.7.0.tgz",
-      "integrity": "sha512-uD2pAV0yV6+e7JaWH4KVPbG+zRCrxr/OACyS9tIh+Q/R1vRmh8zGM3yhdrcoiZ7tFOnM72vd6xY11eTrUsSVig==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.8.0.tgz",
+      "integrity": "sha512-Q3Q2O/axQbFi/5Z+BidLB3qhmYdZLTMDagZtsmyH7CktDkZVNV/0UoOGYlqoK06T4cww3XjLSEomXbBu9TlQKQ==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/plugin": "2.8.0",
+        "@parcel/utils": "2.8.0",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/runtime-webextension": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-webextension/-/runtime-webextension-2.7.0.tgz",
-      "integrity": "sha512-+2gGOOR3HUJGdsr/tUsJjs9tvlOsp2rTgGKt77+s1lqU/DYxh/n6KCSy+7a2DYtnBtZxE6LQhX6g/p4C2hkmMg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-webextension/-/runtime-webextension-2.8.0.tgz",
+      "integrity": "sha512-pfE30DHlw55GOTxp5k5NkCk2ccgJouF/JtCgHaAJdLqiEoqltsta6yFhHQj9ZLUV1qtjd5MxfIs5xOVXGp8SHw==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/plugin": "2.8.0",
+        "@parcel/utils": "2.8.0",
         "nullthrows": "^1.1.1"
       }
     },
@@ -3571,15 +3548,15 @@
       }
     },
     "@parcel/transformer-babel": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.7.0.tgz",
-      "integrity": "sha512-7iklDXXnKH1530+QbI+e4kIJ+Q1puA1ulRS10db3aUJMj5GnvXGDFwhSZ7+T1ps66QHO7cVO29VlbqiRDarH1Q==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.8.0.tgz",
+      "integrity": "sha512-ie+wFe9pucdnRyX2PTN9amOHrhr/IOwUEAfTz/3dPydOYCuX7ErEngCpI9fBzdYE2AV6/noEwC2Mjeoyz9mT2A==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/plugin": "2.7.0",
-        "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/diagnostic": "2.8.0",
+        "@parcel/plugin": "2.8.0",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/utils": "2.8.0",
         "browserslist": "^4.6.6",
         "json5": "^2.2.0",
         "nullthrows": "^1.1.1",
@@ -3587,29 +3564,29 @@
       }
     },
     "@parcel/transformer-css": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.7.0.tgz",
-      "integrity": "sha512-J4EpWK9spQpXyNCmKK8Xnane0xW/1B/EAmfp7Fiv7g+5yUjY4ODf4KUugvE+Eb2gekPkhOKNHermO2KrX0/PFA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.8.0.tgz",
+      "integrity": "sha512-jCMQSfsxCoepblBAHCYMuNWNPQlqasoD6PfNftMdTlv12aUcnjNIYO9600TVLTL799CrEohljbXcfFn6hDGVWw==",
       "dev": true,
       "requires": {
-        "@parcel/css": "^1.12.2",
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/plugin": "2.7.0",
-        "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/diagnostic": "2.8.0",
+        "@parcel/plugin": "2.8.0",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/utils": "2.8.0",
         "browserslist": "^4.6.6",
+        "lightningcss": "^1.16.1",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/transformer-html": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.7.0.tgz",
-      "integrity": "sha512-wYJl5rn81W+Rlk9oQwDJcjoVsWVDKyeri84FzmlGXOsg0EYgnqOiG+3MDM8GeZjfuGe5fuoum4eqZeS0WdUHXw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.8.0.tgz",
+      "integrity": "sha512-KLcZCWSIItZ1s12Sav3uvfTrwhX92craN9u7V3qUs8ld7ompTKsCdnf+gYmeCyISb5yiFDyYBvTGc1bOXvaDRQ==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/hash": "2.7.0",
-        "@parcel/plugin": "2.7.0",
+        "@parcel/diagnostic": "2.8.0",
+        "@parcel/hash": "2.8.0",
+        "@parcel/plugin": "2.8.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.10.1",
@@ -3618,29 +3595,29 @@
       }
     },
     "@parcel/transformer-image": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.7.0.tgz",
-      "integrity": "sha512-mhi9/R5/ULhCkL2COVIKhNFoLDiZwQgprdaTJr5fnODggVxEX5o7ebFV6KNLMTEkwZUJWoB1hL0ziI0++DtoFA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.8.0.tgz",
+      "integrity": "sha512-hJGsZxGlGEkiUvN8kCxA4DhB6/WrHzcIlZZYEgEien9pLctyc6np6idjdcyudPAhH3LwBPkiyeUfCvLAOA1zkA==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0",
-        "@parcel/workers": "2.7.0",
+        "@parcel/plugin": "2.8.0",
+        "@parcel/utils": "2.8.0",
+        "@parcel/workers": "2.8.0",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/transformer-js": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.7.0.tgz",
-      "integrity": "sha512-mzerR+D4rDomUSIk5RSTa2w+DXBdXUeQrpDO74WCDdpDi1lIl8ppFpqtmU7O6y6p8QsgkmS9b0g/vhcry6CJTA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.8.0.tgz",
+      "integrity": "sha512-C5WTkDRiJGBB9tZa1mBsZwsqZjYEKkOa4mdVym3dMokwhFLUga8WtK7kGw4fmXIq41U8ip4orywj+Rd4mvGVWg==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/plugin": "2.7.0",
-        "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.7.0",
-        "@parcel/workers": "2.7.0",
-        "@swc/helpers": "^0.4.2",
+        "@parcel/diagnostic": "2.8.0",
+        "@parcel/plugin": "2.8.0",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/utils": "2.8.0",
+        "@parcel/workers": "2.8.0",
+        "@swc/helpers": "^0.4.12",
         "browserslist": "^4.6.6",
         "detect-libc": "^1.0.3",
         "nullthrows": "^1.1.1",
@@ -3649,25 +3626,25 @@
       }
     },
     "@parcel/transformer-json": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.7.0.tgz",
-      "integrity": "sha512-RQjuxBpYOch+kr4a0zi77KJtOLTPYRM7iq4NN80zKnA0r0dwDUCxZBtaj2l0O0o3R4MMJnm+ncP+cB7XR7dZYA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.8.0.tgz",
+      "integrity": "sha512-Pp5gROSMpzFDEI6KA2APuSpft6eXZxFgTPV6Xx9pElqseod3iL5+RnpMNV/nv76Ai2bcMEiafus5Pb09vjHgbQ==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.7.0",
+        "@parcel/plugin": "2.8.0",
         "json5": "^2.2.0"
       }
     },
     "@parcel/transformer-postcss": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.7.0.tgz",
-      "integrity": "sha512-b6RskXBWf0MjpC9qjR2dQ1ZdRnlOiKYseG5CEovWCqM218RtdydFKz7jS+5Gxkb6qBtOG7zGPONXdPe+gTILcA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.8.0.tgz",
+      "integrity": "sha512-45Ij+cgwXprd1sCLmaMIlCbPz3eEwolGHizgZmXl5l4yjlE2wGyzodhxLpBk1PWu7OxxWRbLnJIlvMYf7Vfw0g==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/hash": "2.7.0",
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/diagnostic": "2.8.0",
+        "@parcel/hash": "2.8.0",
+        "@parcel/plugin": "2.8.0",
+        "@parcel/utils": "2.8.0",
         "clone": "^2.1.1",
         "nullthrows": "^1.1.1",
         "postcss-value-parser": "^4.2.0",
@@ -3675,13 +3652,13 @@
       }
     },
     "@parcel/transformer-posthtml": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.7.0.tgz",
-      "integrity": "sha512-cP8YOiSynWJ1ycmBlhnnHeuQb2cwmklZ+BNyLUktj5p78kDy2de7VjX+dRNRHoW4H9OgEcSF4UEfDVVz5RYIhw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.8.0.tgz",
+      "integrity": "sha512-KrkKBFDW5PNZpr2Ha711eIABQOiJQKvfwfVs3CVpJK5wSADkappDk7CQ0mISPjhamFJ6xx/sNsi7e871I8R9lg==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/plugin": "2.8.0",
+        "@parcel/utils": "2.8.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.10.1",
@@ -3690,34 +3667,34 @@
       }
     },
     "@parcel/transformer-raw": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.7.0.tgz",
-      "integrity": "sha512-sDnItWCFSDez0izK1i5cgv+kXzZTbcJh4rNpVIgmE1kBLvAz608sqgcCkavb2wVJIvLesxYM+5G4p1CwkDlZ1g==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.8.0.tgz",
+      "integrity": "sha512-uEbj+kE70vg2Gmdji/AIXPK13s5aQRw7X+xWs3vNpY2oymyMRHbfx1izJFWBh+kxu6Yo6q6qsekkh2rNHEHIUA==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.7.0"
+        "@parcel/plugin": "2.8.0"
       }
     },
     "@parcel/transformer-react-refresh-wrap": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.7.0.tgz",
-      "integrity": "sha512-1vRmIJzyBA1nIiXTAU6tZExq2FvJj/2F0ft6KDw8GYPv0KjmdiPo/PmaZ7JeSVOM6SdXQIQCbTmp1vkMP7DtkA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.8.0.tgz",
+      "integrity": "sha512-d7G6wBdlwVXLkhC7EO/3UkUOfEOJvsIsQUCEujsrdFF+nfBElXw/TZ+KP8UkmrwMdD0spU/8cKoTyi5k19vt6w==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/plugin": "2.8.0",
+        "@parcel/utils": "2.8.0",
         "react-refresh": "^0.9.0"
       }
     },
     "@parcel/transformer-svg": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.7.0.tgz",
-      "integrity": "sha512-ioER37zceuuE+K6ZrnjCyMUWEnv+63hIAFResc1OXxRhyt+7kzMz9ZqK0Mt6QMLwl1dxhkLmrU41n9IxzKZuSQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.8.0.tgz",
+      "integrity": "sha512-8S6yZoUTCbHOnuWY3M50fscTpI8414945I44fmed+C1e36TnWem8FifuVtGkRZeR8pokF453lmmwWG1eH/4U3w==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/hash": "2.7.0",
-        "@parcel/plugin": "2.7.0",
+        "@parcel/diagnostic": "2.8.0",
+        "@parcel/hash": "2.8.0",
+        "@parcel/plugin": "2.8.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.10.1",
@@ -3726,52 +3703,52 @@
       }
     },
     "@parcel/transformer-webextension": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-webextension/-/transformer-webextension-2.7.0.tgz",
-      "integrity": "sha512-r7mQJ91oVnL9gMvqURlaq4ru95/685utOc51QaOfSCYjuEbosvPUIDXDRAXFVLea56iLP5nIUsrUGtycE6zsQg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-webextension/-/transformer-webextension-2.8.0.tgz",
+      "integrity": "sha512-pGxATimkO7r8JbSysDD45YMmDvk4Tk2AHRQs5mLU/y7QwpT6d8zI30W4+ZpgDqx52Ih5BB2RlaGV1gZeLlpXqg==",
       "dev": true,
       "requires": {
         "@mischnic/json-sourcemap": "^0.1.0",
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/diagnostic": "2.8.0",
+        "@parcel/plugin": "2.8.0",
+        "@parcel/utils": "2.8.0",
         "content-security-policy-parser": "^0.3.0"
       }
     },
     "@parcel/types": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.7.0.tgz",
-      "integrity": "sha512-+dhXVUnseTCpJvBTGMp0V6X13z6O/A/+CUtwEpMGZ8XSmZ4Gk44GvaTiBOp0bJpWG4fvCKp+UmC8PYbrDiiziw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.8.0.tgz",
+      "integrity": "sha512-DeN3vCnVl9onjtyWxpbP7LwRslVEko4kBaM7yILsuQjEnXmaIOsqIf6FQJOUOPBtQTFFNeQQ2qyf5XoO/rkJ8g==",
       "dev": true,
       "requires": {
-        "@parcel/cache": "2.7.0",
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/fs": "2.7.0",
-        "@parcel/package-manager": "2.7.0",
-        "@parcel/source-map": "^2.0.0",
-        "@parcel/workers": "2.7.0",
+        "@parcel/cache": "2.8.0",
+        "@parcel/diagnostic": "2.8.0",
+        "@parcel/fs": "2.8.0",
+        "@parcel/package-manager": "2.8.0",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/workers": "2.8.0",
         "utility-types": "^3.10.0"
       }
     },
     "@parcel/utils": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.7.0.tgz",
-      "integrity": "sha512-jNZ5bIGg1r1RDRKi562o4kuVwnz+XJ2Ie3b0Zwrqwvgfj6AbRFIKzDd+h85dWWmcDYzKUbHp11u6VJl1u8Vapg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.0.tgz",
+      "integrity": "sha512-r4ACsGtW7zkMUIgwQyOVtPAFiy8L81gbz4tMIRSqyQKnkW7oEHcQ3uN1/LPxj2yfkyQLmhJxmtptLUy9j53rcw==",
       "dev": true,
       "requires": {
-        "@parcel/codeframe": "2.7.0",
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/hash": "2.7.0",
-        "@parcel/logger": "2.7.0",
-        "@parcel/markdown-ansi": "2.7.0",
-        "@parcel/source-map": "^2.0.0",
+        "@parcel/codeframe": "2.8.0",
+        "@parcel/diagnostic": "2.8.0",
+        "@parcel/hash": "2.8.0",
+        "@parcel/logger": "2.8.0",
+        "@parcel/markdown-ansi": "2.8.0",
+        "@parcel/source-map": "^2.1.1",
         "chalk": "^4.1.0"
       }
     },
     "@parcel/watcher": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.0.5.tgz",
-      "integrity": "sha512-x0hUbjv891omnkcHD7ZOhiyyUqUUR6MNjq89JhEI3BxppeKWAm6NPQsqqRrAkCJBogdT/o/My21sXtTI9rJIsw==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.0.7.tgz",
+      "integrity": "sha512-gc3hoS6e+2XdIQ4HHljDB1l0Yx2EWh/sBBtCEFNKGSMlwASWeAQsOY/fPbxOBcZ/pg0jBh4Ga+4xHlZc4faAEQ==",
       "dev": true,
       "requires": {
         "node-addon-api": "^3.2.1",
@@ -3779,23 +3756,23 @@
       }
     },
     "@parcel/workers": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.7.0.tgz",
-      "integrity": "sha512-99VfaOX+89+RaoTSyH9ZQtkMBFZBFMvJmVJ/GeJT6QCd2wtKBStTHlaSnQOkLD/iRjJCNwV2xpZmm8YkTwV+hg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.8.0.tgz",
+      "integrity": "sha512-vAzoC/wPHLQnyy9P/TrSPftY8F3MhZqPTFi681mxVtLWA3t7wiNlw1zDVKRDP8m5XS1yQOr8Q56CAHyRexhc8g==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/logger": "2.7.0",
-        "@parcel/types": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/diagnostic": "2.8.0",
+        "@parcel/logger": "2.8.0",
+        "@parcel/types": "2.8.0",
+        "@parcel/utils": "2.8.0",
         "chrome-trace-event": "^1.0.2",
         "nullthrows": "^1.1.1"
       }
     },
     "@swc/helpers": {
-      "version": "0.4.12",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.12.tgz",
-      "integrity": "sha512-R6RmwS9Dld5lNvwKlPn62+piU+WDG1sMfsnfJioXCciyko/gZ0DQ4Mqglhq1iGU1nQ/RcGkAwfMH+elMSkJH3Q==",
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz",
+      "integrity": "sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==",
       "dev": true,
       "requires": {
         "tslib": "^2.4.0"
@@ -3826,9 +3803,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+      "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
       "dev": true
     },
     "ansi-styles": {
@@ -3880,9 +3857,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001418",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001418.tgz",
-      "integrity": "sha512-oIs7+JL3K9JRQ3jPZjlH6qyYDp+nBTCais7hjh0s+fuBwufc7uZ7hPYMXrDOJhV360KGMTcczMRObk0/iMqZRg==",
+      "version": "1.0.30001434",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001434.tgz",
+      "integrity": "sha512-aOBHrLmTQw//WFa2rcF1If9fa3ypkC1wzqqiKHgfdrXTWcU8C4gKVZT77eQAPWN1APys3+uQ0Df07rKauXGEYA==",
       "dev": true
     },
     "chalk": {
@@ -3935,9 +3912,9 @@
       "dev": true
     },
     "cosmiconfig": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
-      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
       "dev": true,
       "requires": {
         "@types/parse-json": "^4.0.0",
@@ -4049,9 +4026,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.4.277",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.277.tgz",
-      "integrity": "sha512-Ej4VyUfGdVY5D2J5WHAVNqrEFBKgeNcX7p/bBQU4x/VKwvnyEvGd62NEkIK3lykLEe9Cg4MCcoWAa+u97o0u/A==",
+      "version": "1.4.284",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
+      "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
       "dev": true
     },
     "entities": {
@@ -4088,9 +4065,9 @@
       "dev": true
     },
     "globals": {
-      "version": "13.17.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
-      "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
+      "version": "13.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.18.0.tgz",
+      "integrity": "sha512-/mR4KI8Ps2spmoc0Ulu9L7agOF0du1CZNQ3dke8yItYlyKNmGrkONemBbd6V8UTc1Wgcqn21t3WYB7dbRmh6/A==",
       "dev": true,
       "requires": {
         "type-fest": "^0.20.2"
@@ -4103,9 +4080,9 @@
       "dev": true
     },
     "htmlnano": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/htmlnano/-/htmlnano-2.0.2.tgz",
-      "integrity": "sha512-+ZrQFS4Ub+zd+/fWwfvoYCEGNEa0/zrpys6CyXxvZDwtL7Pl+pOtRkiujyvBQ7Lmfp7/iEPxtOFgxWA16Gkj3w==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/htmlnano/-/htmlnano-2.0.3.tgz",
+      "integrity": "sha512-S4PGGj9RbdgW8LhbILNK7W9JhmYP8zmDY7KDV/8eCiJBQJlbmltp5I0gv8c5ntLljfdxxfmJ+UJVSqyH4mb41A==",
       "dev": true,
       "requires": {
         "cosmiconfig": "^7.0.1",
@@ -4184,75 +4161,75 @@
       "dev": true
     },
     "lightningcss": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.16.0.tgz",
-      "integrity": "sha512-5+ZS9h+xeADcJTF2oRCT3yNZBlDYyOgQSdrWNBCqsIwm8ucKbF061OBVv/WHP4Zk8FToNhwFklk/hMuOngqsIg==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.16.1.tgz",
+      "integrity": "sha512-zU8OTaps3VAodmI2MopfqqOQQ4A9L/2Eo7xoTH/4fNkecy6ftfiGwbbRMTQqtIqJjRg3f927e+lnyBBPhucY1Q==",
       "dev": true,
       "requires": {
         "detect-libc": "^1.0.3",
-        "lightningcss-darwin-arm64": "1.16.0",
-        "lightningcss-darwin-x64": "1.16.0",
-        "lightningcss-linux-arm-gnueabihf": "1.16.0",
-        "lightningcss-linux-arm64-gnu": "1.16.0",
-        "lightningcss-linux-arm64-musl": "1.16.0",
-        "lightningcss-linux-x64-gnu": "1.16.0",
-        "lightningcss-linux-x64-musl": "1.16.0",
-        "lightningcss-win32-x64-msvc": "1.16.0"
+        "lightningcss-darwin-arm64": "1.16.1",
+        "lightningcss-darwin-x64": "1.16.1",
+        "lightningcss-linux-arm-gnueabihf": "1.16.1",
+        "lightningcss-linux-arm64-gnu": "1.16.1",
+        "lightningcss-linux-arm64-musl": "1.16.1",
+        "lightningcss-linux-x64-gnu": "1.16.1",
+        "lightningcss-linux-x64-musl": "1.16.1",
+        "lightningcss-win32-x64-msvc": "1.16.1"
       }
     },
     "lightningcss-darwin-arm64": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.16.0.tgz",
-      "integrity": "sha512-gIhz6eZFwsC4oVMjBGQ3QWDdLQY7vcXFyM/x91PilgHqu63B9uBa10EZA75YoTEkbKhoz0uDCqyHh/EoF1GrkQ==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.16.1.tgz",
+      "integrity": "sha512-/J898YSAiGVqdybHdIF3Ao0Hbh2vyVVj5YNm3NznVzTSvkOi3qQCAtO97sfmNz+bSRHXga7ZPLm+89PpOM5gAg==",
       "dev": true,
       "optional": true
     },
     "lightningcss-darwin-x64": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.16.0.tgz",
-      "integrity": "sha512-kLPi+OEpDj3UGY6DC8TfjbcULJDKMP+TVKSlrEkNGn8t1YRzi2g4oy7UVTSB5AnSbT0CusUItzdVjHQ49EdoNA==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.16.1.tgz",
+      "integrity": "sha512-vyKCNPRNRqke+5i078V+N0GLfMVLEaNcqIcv28hA/vUNRGk/90EDkDB9EndGay0MoPIrC2y0qE3Y74b/OyedqQ==",
       "dev": true,
       "optional": true
     },
     "lightningcss-linux-arm-gnueabihf": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.16.0.tgz",
-      "integrity": "sha512-oSwEbvXUPr//H/ainBRJXTxHerlheee/KgkTTmAQWiVnt8HV+bRohTBWWPBy5ZArgiGLwj7ogv45istgljPN2Q==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.16.1.tgz",
+      "integrity": "sha512-0AJC52l40VbrzkMJz6qRvlqVVGykkR2MgRS4bLjVC2ab0H0I/n4p6uPZXGvNIt5gw1PedeND/hq+BghNdgfuPQ==",
       "dev": true,
       "optional": true
     },
     "lightningcss-linux-arm64-gnu": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.16.0.tgz",
-      "integrity": "sha512-Drq9BSVIvmV9zsDJbCZWCulMvKMQWFIlYXPCKV/iwRj+ZAJ1BRngma0cNHB6uW7Wac8Jg04CJN5IA4ELE3J+cQ==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.16.1.tgz",
+      "integrity": "sha512-NqxYXsRvI3/Fb9AQLXKrYsU0Q61LqKz5It+Es9gidsfcw1lamny4lmlUgO3quisivkaLCxEkogaizcU6QeZeWQ==",
       "dev": true,
       "optional": true
     },
     "lightningcss-linux-arm64-musl": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.16.0.tgz",
-      "integrity": "sha512-1QXWStnTEo4RFQf0mfGhRyNUeEHilCZ0NA97XgwKwrYr/M7sYKU/1HWY00dPxFJ6GITR2pfJGo9xi3ScSSBxbA==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.16.1.tgz",
+      "integrity": "sha512-VUPQ4dmB9yDQxpJF8/imtwNcbIPzlL6ArLHSUInOGxipDk1lOAklhUjbKUvlL3HVlDwD3WHCxggAY01WpFcjiA==",
       "dev": true,
       "optional": true
     },
     "lightningcss-linux-x64-gnu": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.16.0.tgz",
-      "integrity": "sha512-gD2eQYD5OFs1p83R0TcMCEc5HRyJES4lR4THmclv7khm3dc9vc+2VT0kFBPxO1L2AwlZuvXaaMan7X1Ul7uSfA==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.16.1.tgz",
+      "integrity": "sha512-A40Jjnbellnvh4YF+kt047GLnUU59iLN2LFRCyWQG+QqQZeXOCzXfTQ6EJB4yvHB1mQvWOVdAzVrtEmRw3Vh8g==",
       "dev": true,
       "optional": true
     },
     "lightningcss-linux-x64-musl": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.16.0.tgz",
-      "integrity": "sha512-HJsKeYxloEvg2WCQhtYPqzZUliLu9JBJNeI5y9cPQeDR/7ayGGLbVhJaotPtzJkElOFL/SaXsS+FRuH4w+yafg==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.16.1.tgz",
+      "integrity": "sha512-VZf76GxW+8mk238tpw0u9R66gBi/m0YB0TvD54oeGiOqvTZ/mabkBkbsuXTSWcKYj8DSrLW+A42qu+6PLRsIgA==",
       "dev": true,
       "optional": true
     },
     "lightningcss-win32-x64-msvc": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.16.0.tgz",
-      "integrity": "sha512-h4ayyAlOMLUHV9NdofcIu79aEjmly93adVxcg5wDJpkvMiwDTufEN30M8G4gGcjo1JE5jFjAcyQcRpXYkYcemA==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.16.1.tgz",
+      "integrity": "sha512-Djy+UzlTtJMayVJU3eFuUW5Gdo+zVTNPJhlYw25tNC9HAoMCkIdSDDrGsWEdEyibEV7xwB8ySTmLuxilfhBtgg==",
       "dev": true,
       "optional": true
     },
@@ -4296,27 +4273,27 @@
       "dev": true
     },
     "msgpackr": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.7.2.tgz",
-      "integrity": "sha512-mWScyHTtG6TjivXX9vfIy2nBtRupaiAj0HQ2mtmpmYujAmqZmaaEVPaSZ1NKLMvicaMLFzEaMk0ManxMRg8rMQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.8.0.tgz",
+      "integrity": "sha512-1Cos3r86XACdjLVY4CN8r72Cgs5lUzxSON6yb81sNZP9vC9nnBrEbu1/ldBhuR9BKejtoYV5C9UhmYUvZFJSNQ==",
       "dev": true,
       "requires": {
-        "msgpackr-extract": "^2.1.2"
+        "msgpackr-extract": "^2.2.0"
       }
     },
     "msgpackr-extract": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-2.1.2.tgz",
-      "integrity": "sha512-cmrmERQFb19NX2JABOGtrKdHMyI6RUyceaPBQ2iRz9GnDkjBWFjNJC0jyyoOfZl2U/LZE3tQCCQc4dlRyA8mcA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-2.2.0.tgz",
+      "integrity": "sha512-0YcvWSv7ZOGl9Od6Y5iJ3XnPww8O7WLcpYMDwX+PAA/uXLDtyw94PJv9GLQV/nnp3cWlDhMoyKZIQLrx33sWog==",
       "dev": true,
       "optional": true,
       "requires": {
-        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "2.1.2",
-        "@msgpackr-extract/msgpackr-extract-darwin-x64": "2.1.2",
-        "@msgpackr-extract/msgpackr-extract-linux-arm": "2.1.2",
-        "@msgpackr-extract/msgpackr-extract-linux-arm64": "2.1.2",
-        "@msgpackr-extract/msgpackr-extract-linux-x64": "2.1.2",
-        "@msgpackr-extract/msgpackr-extract-win32-x64": "2.1.2",
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "2.2.0",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "2.2.0",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "2.2.0",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "2.2.0",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "2.2.0",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "2.2.0",
         "node-gyp-build-optional-packages": "5.0.3"
       }
     },
@@ -4371,21 +4348,21 @@
       "dev": true
     },
     "parcel": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.7.0.tgz",
-      "integrity": "sha512-pRYwnivwtNP0tip8xYSo4zCB0XhLt7/gJzP1p8OovCqkmFjG9VG+GW9TcAKqMIo0ovEa9tT+/s6gY1Qy+BONGQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.8.0.tgz",
+      "integrity": "sha512-p7Fo75CeMw5HC1luovYpBjzPbAJv/Gn7lxcs4f0LxcwBCWbkQ73zHgJXJQqnM38qQABEYEiQq6000+j+k5U/Mw==",
       "dev": true,
       "requires": {
-        "@parcel/config-default": "2.7.0",
-        "@parcel/core": "2.7.0",
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/events": "2.7.0",
-        "@parcel/fs": "2.7.0",
-        "@parcel/logger": "2.7.0",
-        "@parcel/package-manager": "2.7.0",
-        "@parcel/reporter-cli": "2.7.0",
-        "@parcel/reporter-dev-server": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/config-default": "2.8.0",
+        "@parcel/core": "2.8.0",
+        "@parcel/diagnostic": "2.8.0",
+        "@parcel/events": "2.8.0",
+        "@parcel/fs": "2.8.0",
+        "@parcel/logger": "2.8.0",
+        "@parcel/package-manager": "2.8.0",
+        "@parcel/reporter-cli": "2.8.0",
+        "@parcel/reporter-dev-server": "2.8.0",
+        "@parcel/utils": "2.8.0",
         "chalk": "^4.1.0",
         "commander": "^7.0.0",
         "get-port": "^4.2.0",
@@ -4471,9 +4448,9 @@
       }
     },
     "prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.0.tgz",
+      "integrity": "sha512-9Lmg8hTFZKG0Asr/kW9Bp8tJjRVluO8EJQVfY2T7FMw9T5jy4I/Uvx0Rca/XWf50QQ1/SS48+6IJWnrb+2yemA==",
       "dev": true
     },
     "private-ip": {
@@ -4500,9 +4477,9 @@
       "dev": true
     },
     "regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
       "dev": true
     },
     "resolve-from": {
@@ -4576,9 +4553,9 @@
       "dev": true
     },
     "terser": {
-      "version": "5.15.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.1.tgz",
-      "integrity": "sha512-K1faMUvpm/FBxjBXud0LWVAGxmvoPbZbfTCYbSgaaYQaIXI3/TdI7a7ZGA73Zrou6Q8Zmz3oeUTsp/dj+ag2Xw==",
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.0.tgz",
+      "integrity": "sha512-KjTV81QKStSfwbNiwlBXfcgMcOloyuRdb62/iLFPGBcVNF4EXjhdYBhYHmbJpiBrVxZhDvltE11j+LBQUxEEJg==",
       "dev": true,
       "requires": {
         "@jridgewell/source-map": "^0.3.2",
@@ -4602,9 +4579,9 @@
       "dev": true
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
       "dev": true
     },
     "type-fest": {
@@ -4614,9 +4591,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
+      "integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
       "dev": true
     },
     "update-browserslist-db": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@types/webextension-polyfill": "^0.9.1",
         "parcel": "^2.8.0",
         "prettier": "^2.8.0",
+        "prettier-plugin-organize-imports": "^3.2.0",
         "typescript": "^4.9.3",
         "webextension-polyfill": "^0.10.0"
       }
@@ -2551,6 +2552,26 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/prettier-plugin-organize-imports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-3.2.0.tgz",
+      "integrity": "sha512-jeZ13YVKgXYCzkuwnoR6saKxJmdRYWMxS2G/su1V3qDWqTo1Q5iSoTblBxsXXAmomXfPqa/uA7YCK0/S86KLOQ==",
+      "dev": true,
+      "peerDependencies": {
+        "@volar/vue-language-plugin-pug": "^1.0.4",
+        "@volar/vue-typescript": "^1.0.4",
+        "prettier": ">=2.0",
+        "typescript": ">=2.9"
+      },
+      "peerDependenciesMeta": {
+        "@volar/vue-language-plugin-pug": {
+          "optional": true
+        },
+        "@volar/vue-typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/private-ip": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/private-ip/-/private-ip-2.3.4.tgz",
@@ -4451,6 +4472,12 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.0.tgz",
       "integrity": "sha512-9Lmg8hTFZKG0Asr/kW9Bp8tJjRVluO8EJQVfY2T7FMw9T5jy4I/Uvx0Rca/XWf50QQ1/SS48+6IJWnrb+2yemA==",
+      "dev": true
+    },
+    "prettier-plugin-organize-imports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-3.2.0.tgz",
+      "integrity": "sha512-jeZ13YVKgXYCzkuwnoR6saKxJmdRYWMxS2G/su1V3qDWqTo1Q5iSoTblBxsXXAmomXfPqa/uA7YCK0/S86KLOQ==",
       "dev": true
     },
     "private-ip": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,9 @@
         "@parcel/config-webextension": "^2.8.0",
         "@types/webextension-polyfill": "^0.9.1",
         "parcel": "^2.8.0",
+        "postcss": "^8.4.19",
         "prettier": "^2.8.0",
+        "prettier-plugin-css-order": "^1.3.0",
         "prettier-plugin-organize-imports": "^3.2.1",
         "typescript": "^4.9.3",
         "webextension-polyfill": "^0.10.0"
@@ -1715,6 +1717,18 @@
         "node": ">=10"
       }
     },
+    "node_modules/css-declaration-sorter": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.3.1.tgz",
+      "integrity": "sha512-fBffmak0bPAnyqc/HO8C3n2sHrp9wcqQz6ES9koRF2/mLOVAx9zIQ3Y7R29sYCteTPqMCwns4WYQoCX91Xl3+w==",
+      "dev": true,
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.9"
+      }
+    },
     "node_modules/css-select": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
@@ -2339,6 +2353,18 @@
         "@msgpackr-extract/msgpackr-extract-win32-x64": "2.2.0"
       }
     },
+    "node_modules/nanoid": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "dev": true,
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/netmask": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
@@ -2482,6 +2508,64 @@
       "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
       "dev": true
     },
+    "node_modules/postcss": {
+      "version": "8.4.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.19.tgz",
+      "integrity": "sha512-h+pbPsyhlYj6N2ozBmHhHrs9DzGmbaarbLvWipMRO7RLS+v4onj26MPFXA5OBYFxyqYhUJK456SwDcY9H2/zsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.4",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-less": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-6.0.0.tgz",
+      "integrity": "sha512-FPX16mQLyEjLzEuuJtxA8X3ejDLNGGEG503d2YGZR5Ask1SpDN8KmZUMpzCvyalWRywAn1n1VOA5dcqfCLo5rg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "postcss": "^8.3.5"
+      }
+    },
+    "node_modules/postcss-scss": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.5.tgz",
+      "integrity": "sha512-F7xpB6TrXyqUh3GKdyB4Gkp3QL3DDW1+uI+gxx/oJnUt/qXI4trj5OGlp9rOKdoABGULuqtqeG+3HEVQk4DjmA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss-scss"
+        }
+      ],
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.3.3"
+      }
+    },
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
@@ -2550,6 +2634,24 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-css-order": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-css-order/-/prettier-plugin-css-order-1.3.0.tgz",
+      "integrity": "sha512-wOS4qlbUARCoiiuOG0TiB/j751soC3+gUnMMva5HVWKvHJdLNYqh+jXK3MvvixR6xkJVPxHSF7rIIhkHIuHTFg==",
+      "dev": true,
+      "dependencies": {
+        "css-declaration-sorter": "^6.2.2",
+        "postcss-less": "^6.0.0",
+        "postcss-scss": "^4.0.3",
+        "sync-threads": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "prettier": "2.x"
       }
     },
     "node_modules/prettier-plugin-organize-imports": {
@@ -2651,6 +2753,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-support": {
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
@@ -2700,6 +2811,12 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/sync-threads": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sync-threads/-/sync-threads-1.0.1.tgz",
+      "integrity": "sha512-hIdwt/c/e1ONnr2RJmfBxEAj/J6KQQWKdToF3Qw8ZNRsTNNteGkOe63rQy9I7J5UNlr8Yl0wkzIr9wgLY94x0Q==",
+      "dev": true
     },
     "node_modules/term-size": {
       "version": "2.2.1",
@@ -3945,6 +4062,12 @@
         "yaml": "^1.10.0"
       }
     },
+    "css-declaration-sorter": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.3.1.tgz",
+      "integrity": "sha512-fBffmak0bPAnyqc/HO8C3n2sHrp9wcqQz6ES9koRF2/mLOVAx9zIQ3Y7R29sYCteTPqMCwns4WYQoCX91Xl3+w==",
+      "dev": true
+    },
     "css-select": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
@@ -4318,6 +4441,12 @@
         "node-gyp-build-optional-packages": "5.0.3"
       }
     },
+    "nanoid": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "dev": true
+    },
     "netmask": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
@@ -4423,6 +4552,29 @@
       "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
       "dev": true
     },
+    "postcss": {
+      "version": "8.4.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.19.tgz",
+      "integrity": "sha512-h+pbPsyhlYj6N2ozBmHhHrs9DzGmbaarbLvWipMRO7RLS+v4onj26MPFXA5OBYFxyqYhUJK456SwDcY9H2/zsA==",
+      "dev": true,
+      "requires": {
+        "nanoid": "^3.3.4",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      }
+    },
+    "postcss-less": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-6.0.0.tgz",
+      "integrity": "sha512-FPX16mQLyEjLzEuuJtxA8X3ejDLNGGEG503d2YGZR5Ask1SpDN8KmZUMpzCvyalWRywAn1n1VOA5dcqfCLo5rg==",
+      "dev": true
+    },
+    "postcss-scss": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.5.tgz",
+      "integrity": "sha512-F7xpB6TrXyqUh3GKdyB4Gkp3QL3DDW1+uI+gxx/oJnUt/qXI4trj5OGlp9rOKdoABGULuqtqeG+3HEVQk4DjmA==",
+      "dev": true
+    },
     "postcss-value-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
@@ -4473,6 +4625,18 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.0.tgz",
       "integrity": "sha512-9Lmg8hTFZKG0Asr/kW9Bp8tJjRVluO8EJQVfY2T7FMw9T5jy4I/Uvx0Rca/XWf50QQ1/SS48+6IJWnrb+2yemA==",
       "dev": true
+    },
+    "prettier-plugin-css-order": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-css-order/-/prettier-plugin-css-order-1.3.0.tgz",
+      "integrity": "sha512-wOS4qlbUARCoiiuOG0TiB/j751soC3+gUnMMva5HVWKvHJdLNYqh+jXK3MvvixR6xkJVPxHSF7rIIhkHIuHTFg==",
+      "dev": true,
+      "requires": {
+        "css-declaration-sorter": "^6.2.2",
+        "postcss-less": "^6.0.0",
+        "postcss-scss": "^4.0.3",
+        "sync-threads": "^1.0.1"
+      }
     },
     "prettier-plugin-organize-imports": {
       "version": "3.2.1",
@@ -4533,6 +4697,12 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true
     },
+    "source-map-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "dev": true
+    },
     "source-map-support": {
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
@@ -4572,6 +4742,12 @@
         "picocolors": "^1.0.0",
         "stable": "^0.1.8"
       }
+    },
+    "sync-threads": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sync-threads/-/sync-threads-1.0.1.tgz",
+      "integrity": "sha512-hIdwt/c/e1ONnr2RJmfBxEAj/J6KQQWKdToF3Qw8ZNRsTNNteGkOe63rQy9I7J5UNlr8Yl0wkzIr9wgLY94x0Q==",
+      "dev": true
     },
     "term-size": {
       "version": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ttv-lol-pro",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "TTV LOL PRO removes livestream ads from Twitch",
   "@parcel/bundler-default": {
     "minBundles": 10000000,

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@types/webextension-polyfill": "^0.9.1",
     "parcel": "^2.8.0",
     "prettier": "^2.8.0",
+    "prettier-plugin-organize-imports": "^3.2.0",
     "typescript": "^4.9.3",
     "webextension-polyfill": "^0.10.0"
   },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@types/webextension-polyfill": "^0.9.1",
     "parcel": "^2.8.0",
     "prettier": "^2.8.0",
-    "prettier-plugin-organize-imports": "^3.2.0",
+    "prettier-plugin-organize-imports": "^3.2.1",
     "typescript": "^4.9.3",
     "webextension-polyfill": "^0.10.0"
   },

--- a/package.json
+++ b/package.json
@@ -40,7 +40,9 @@
     "@parcel/config-webextension": "^2.8.0",
     "@types/webextension-polyfill": "^0.9.1",
     "parcel": "^2.8.0",
+    "postcss": "^8.4.19",
     "prettier": "^2.8.0",
+    "prettier-plugin-css-order": "^1.3.0",
     "prettier-plugin-organize-imports": "^3.2.1",
     "typescript": "^4.9.3",
     "webextension-polyfill": "^0.10.0"

--- a/package.json
+++ b/package.json
@@ -37,11 +37,11 @@
     "private-ip": "^2.3.4"
   },
   "devDependencies": {
-    "@parcel/config-webextension": "^2.7.0",
+    "@parcel/config-webextension": "^2.8.0",
     "@types/webextension-polyfill": "^0.9.1",
-    "parcel": "^2.7.0",
-    "prettier": "^2.7.1",
-    "typescript": "^4.8.4",
+    "parcel": "^2.8.0",
+    "prettier": "^2.8.0",
+    "typescript": "^4.9.3",
     "webextension-polyfill": "^0.10.0"
   },
   "private": true

--- a/src/background/handlers/onBeforeRequest.ts
+++ b/src/background/handlers/onBeforeRequest.ts
@@ -16,6 +16,12 @@ export default function onBeforeRequest(
     _type.toLowerCase() === "vod" ? PlaylistType.VOD : PlaylistType.Playlist;
   const searchParams = new URLSearchParams(_params);
 
+  if (playlistType === PlaylistType.VOD && store.state.disableVodRedirect) {
+    console.log(`${streamId}: VOD proxying is disabled (Options)`);
+    setStreamStatus(streamId, false, "VOD proxying is disabled (Options)");
+    return {};
+  }
+
   // No redirect if the channel is whitelisted.
   const channelName = streamId.toLowerCase();
   const isWhitelistedChannel = store.state.whitelistedChannels.some(

--- a/src/background/handlers/onBeforeRequest.ts
+++ b/src/background/handlers/onBeforeRequest.ts
@@ -65,10 +65,10 @@ export default function onBeforeRequest(
 
   const status = store.state.streamStatuses[streamId];
   if (status) {
-    if (
-      status.errors.filter(error => Date.now() - error.timestamp < 20000)
-        .length >= 2
-    ) {
+    const recentErrors = status.errors.filter(
+      error => Date.now() - error.timestamp <= 20000 // 20s
+    );
+    if (recentErrors.length >= 2) {
       console.log(`${streamId}: No redirect (Too many errors occurred)`);
       setStreamStatus(streamId, false, "Too many errors occurred");
       return {};

--- a/src/background/handlers/onBeforeRequest.ts
+++ b/src/background/handlers/onBeforeRequest.ts
@@ -8,9 +8,9 @@ export default function onBeforeRequest(
   details: WebRequest.OnBeforeRequestDetailsType
 ): WebRequest.BlockingResponse | Promise<WebRequest.BlockingResponse> {
   const match = TWITCH_API_URL_REGEX.exec(details.url);
-  if (match == null) return {};
-  const [_, _type, streamId, _params] = match;
-  if (_type == null || streamId == null) return {};
+  if (!match) return {};
+  const [, _type, streamId, _params] = match;
+  if (!_type || !streamId) return {};
 
   const playlistType =
     _type.toLowerCase() === "vod" ? PlaylistType.VOD : PlaylistType.Playlist;
@@ -138,7 +138,7 @@ function redirectFirefox(
     tryRedirect(servers[i]);
 
     function tryRedirect(server: string) {
-      if (server == null) {
+      if (!server) {
         // We've reached the end of the `servers` array.
         console.log(`${streamId}: No redirect (All pings failed)`);
         setStreamStatus(streamId, false, "All server pings failed");

--- a/src/background/handlers/onBeforeRequest.ts
+++ b/src/background/handlers/onBeforeRequest.ts
@@ -97,7 +97,7 @@ function redirectChrome(
   playlistType: PlaylistType,
   streamId: string,
   searchParams: URLSearchParams
-) {
+): WebRequest.BlockingResponse {
   const servers = store.state.servers;
 
   for (const server of servers) {

--- a/src/background/handlers/onBeforeRequest.ts
+++ b/src/background/handlers/onBeforeRequest.ts
@@ -1,8 +1,8 @@
-import { PlaylistType, Token } from "../../types";
-import { TWITCH_API_URL_REGEX } from "../../common/ts/regexes";
 import { WebRequest } from "webextension-polyfill";
 import isChrome from "../../common/ts/isChrome";
+import { TWITCH_API_URL_REGEX } from "../../common/ts/regexes";
 import store from "../../store";
+import { PlaylistType, Token } from "../../types";
 
 export default function onBeforeRequest(
   details: WebRequest.OnBeforeRequestDetailsType

--- a/src/background/handlers/onBeforeRequest.ts
+++ b/src/background/handlers/onBeforeRequest.ts
@@ -16,9 +16,12 @@ export default function onBeforeRequest(
     _type.toLowerCase() === "vod" ? PlaylistType.VOD : PlaylistType.Playlist;
   const searchParams = new URLSearchParams(_params);
 
+  // No redirect if VOD proxying is disabled.
   if (playlistType === PlaylistType.VOD && store.state.disableVodRedirect) {
-    console.log(`${streamId}: VOD proxying is disabled (Options)`);
-    setStreamStatus(streamId, false, "VOD proxying is disabled (Options)");
+    console.log(
+      `${streamId}: No redirect (VOD proxying is disabled in Options)`
+    );
+    setStreamStatus(streamId, false, "VOD proxying is disabled in Options");
     return {};
   }
 
@@ -60,7 +63,7 @@ export default function onBeforeRequest(
       // Remove sensitive information for live streams.
       ["token", "sig"].forEach(param => searchParams.delete(param));
     }
-    // Note: TTV LOL's API requires Twitch token for VODs, so we can't remove it.
+    // Note: TTV LOL's API requires a Twitch token for VODs, so we can't remove it.
   }
 
   const status = store.state.streamStatuses[streamId];

--- a/src/background/handlers/onBeforeRequest.ts
+++ b/src/background/handlers/onBeforeRequest.ts
@@ -32,7 +32,7 @@ export default function onBeforeRequest(
     token = JSON.parse(`${searchParams.get("token")}`);
   } catch {}
 
-  if (token != null) {
+  if (token) {
     // No redirect if the user is a subscriber, has Twitch Turbo, or is a partner.
     if (
       token.subscriber === true ||
@@ -64,7 +64,7 @@ export default function onBeforeRequest(
   }
 
   const status = store.state.streamStatuses[streamId];
-  if (status != null) {
+  if (status) {
     if (
       status.errors.filter(error => Date.now() - error.timestamp < 20000)
         .length >= 2

--- a/src/background/handlers/onBeforeRequest.ts
+++ b/src/background/handlers/onBeforeRequest.ts
@@ -56,17 +56,11 @@ export default function onBeforeRequest(
       return {};
     }
 
-    if (store.state.removeTokenFromRequests) {
-      ["token", "sig"].forEach(param => searchParams.delete(param));
-    } else if (playlistType === PlaylistType.Playlist) {
+    if (playlistType === PlaylistType.Playlist) {
       // Remove sensitive information for live streams.
-      delete token.device_id;
-      delete token.user_id;
-      delete token.user_ip;
-      searchParams.delete("sig");
-      searchParams.set("token", JSON.stringify(token));
+      ["token", "sig"].forEach(param => searchParams.delete(param));
     }
-    // Token signature is checked for VODs, so we can't remove it.
+    // Note: TTV LOL's API requires Twitch token for VODs, so we can't remove it.
   }
 
   const status = store.state.streamStatuses[streamId];

--- a/src/background/handlers/onBeforeRequest.ts
+++ b/src/background/handlers/onBeforeRequest.ts
@@ -138,7 +138,7 @@ function redirectFirefox(
     tryRedirect(servers[i]);
 
     function tryRedirect(server: string) {
-      if (!server) {
+      if (server == null) {
         // We've reached the end of the `servers` array.
         console.log(`${streamId}: No redirect (All pings failed)`);
         setStreamStatus(streamId, false, "All server pings failed");

--- a/src/background/handlers/onBeforeSendHeaders.ts
+++ b/src/background/handlers/onBeforeSendHeaders.ts
@@ -7,8 +7,8 @@ import store from "../../store";
 
 function extractProxyCountry(string: string) {
   const match = MANIFEST_PROXY_COUNTRY_REGEX.exec(string);
-  if (match == null) return;
-  const [_, proxyCountry] = match;
+  if (!match) return;
+  const [, proxyCountry] = match;
   return proxyCountry;
 }
 
@@ -43,9 +43,9 @@ export default function onBeforeSendHeaders(
   if (isChrome) return response;
 
   const match = TTV_LOL_API_URL_REGEX.exec(details.url);
-  if (match == null) return response;
-  const [_, streamId] = match;
-  if (streamId == null) return response;
+  if (!match) return response;
+  const [, streamId] = match;
+  if (!streamId) return response;
 
   const filter = browser.webRequest.filterResponseData(details.requestId);
   const decoder = new TextDecoder("utf-8");

--- a/src/background/handlers/onBeforeSendHeaders.ts
+++ b/src/background/handlers/onBeforeSendHeaders.ts
@@ -1,8 +1,9 @@
-import { MANIFEST_PROXY_COUNTRY_REGEX } from "../../common/ts/regexes";
-import { TTV_LOL_API_URL_REGEX } from "../../common/ts/regexes";
-import { WebRequest } from "webextension-polyfill";
-import browser from "webextension-polyfill";
+import browser, { WebRequest } from "webextension-polyfill";
 import isChrome from "../../common/ts/isChrome";
+import {
+  MANIFEST_PROXY_COUNTRY_REGEX,
+  TTV_LOL_API_URL_REGEX,
+} from "../../common/ts/regexes";
 import store from "../../store";
 
 function extractProxyCountry(string: string) {

--- a/src/background/handlers/onBeforeSendHeaders.ts
+++ b/src/background/handlers/onBeforeSendHeaders.ts
@@ -6,30 +6,11 @@ import {
 } from "../../common/ts/regexes";
 import store from "../../store";
 
-function extractProxyCountry(string: string) {
-  const match = MANIFEST_PROXY_COUNTRY_REGEX.exec(string);
-  if (!match) return;
-  const [, proxyCountry] = match;
-  return proxyCountry;
-}
-
-function setStreamStatusProxyCountry(
-  streamId: string,
-  proxyCountry: string | undefined = undefined
-) {
-  if (!proxyCountry) return;
-  const status = store.state.streamStatuses[streamId];
-  store.state.streamStatuses[streamId] = {
-    ...status,
-    proxyCountry: proxyCountry,
-  };
-}
-
 export default function onBeforeSendHeaders(
   details: WebRequest.OnBeforeSendHeadersDetailsType
 ): WebRequest.BlockingResponse {
   if (!details.requestHeaders) {
-    console.error("details.requestHeaders is undefined");
+    console.error("`details.requestHeaders` is undefined");
     return {};
   }
   details.requestHeaders.push({
@@ -52,8 +33,8 @@ export default function onBeforeSendHeaders(
   const decoder = new TextDecoder("utf-8");
 
   filter.ondata = event => {
-    const string = decoder.decode(event.data, { stream: true });
-    const proxyCountry = extractProxyCountry(string);
+    const data = decoder.decode(event.data, { stream: true });
+    const proxyCountry = extractProxyCountry(data);
     if (proxyCountry) {
       setStreamStatusProxyCountry(streamId, proxyCountry);
     }
@@ -65,4 +46,23 @@ export default function onBeforeSendHeaders(
   filter.onstop = () => filter.disconnect();
 
   return response;
+}
+
+function extractProxyCountry(data: string) {
+  const match = MANIFEST_PROXY_COUNTRY_REGEX.exec(data);
+  if (!match) return;
+  const [, proxyCountry] = match;
+  return proxyCountry;
+}
+
+function setStreamStatusProxyCountry(
+  streamId: string,
+  proxyCountry: string | undefined = undefined
+) {
+  if (!proxyCountry) return;
+  const status = store.state.streamStatuses[streamId];
+  store.state.streamStatuses[streamId] = {
+    ...status,
+    proxyCountry: proxyCountry,
+  };
 }

--- a/src/background/handlers/onHeadersReceived.ts
+++ b/src/background/handlers/onHeadersReceived.ts
@@ -6,9 +6,9 @@ export default function onHeadersReceived(
   details: WebRequest.OnHeadersReceivedDetailsType
 ): WebRequest.BlockingResponse {
   const match = TTV_LOL_API_URL_REGEX.exec(details.url);
-  if (match == null) return {};
-  const [_, streamId] = match;
-  if (streamId == null) return {};
+  if (!match) return {};
+  const [, streamId] = match;
+  if (!streamId) return {};
 
   const isServerError = 500 <= details.statusCode && details.statusCode < 600;
   if (isServerError) {

--- a/src/background/handlers/onHeadersReceived.ts
+++ b/src/background/handlers/onHeadersReceived.ts
@@ -1,5 +1,5 @@
-import { TTV_LOL_API_URL_REGEX } from "../../common/ts/regexes";
 import { WebRequest } from "webextension-polyfill";
+import { TTV_LOL_API_URL_REGEX } from "../../common/ts/regexes";
 import store from "../../store";
 
 export default function onHeadersReceived(

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -3,9 +3,9 @@ import store from "../store";
 
 store.addEventListener("load", () => {
   const match = TWITCH_URL_REGEX.exec(location.href);
-  if (match == null) return;
-  const [_, streamId] = match;
-  if (streamId == null) return;
+  if (!match) return;
+  const [, streamId] = match;
+  if (!streamId) return;
 
   if (store.state.streamStatuses[streamId] != null) {
     // Clear errors for stream on page load/reload.

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -7,7 +7,7 @@ store.addEventListener("load", () => {
   const [, streamId] = match;
   if (!streamId) return;
 
-  if (store.state.streamStatuses[streamId] != null) {
+  if (store.state.streamStatuses[streamId]) {
     // Clear errors for stream on page load/reload.
     store.state.streamStatuses[streamId].errors = [];
   }

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -1,7 +1,10 @@
 import { TWITCH_URL_REGEX } from "../common/ts/regexes";
 import store from "../store";
 
-store.addEventListener("load", () => {
+if (store.readyState === "complete") main();
+else store.addEventListener("load", main);
+
+function main() {
   const match = TWITCH_URL_REGEX.exec(location.href);
   if (!match) return;
   const [, streamId] = match;
@@ -11,4 +14,4 @@ store.addEventListener("load", () => {
     // Clear errors for stream on page load/reload.
     store.state.streamStatuses[streamId].errors = [];
   }
-});
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "TTV LOL PRO",
   "description": "TTV LOL PRO removes livestream ads from Twitch.",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "background": {
     "persistent": true,
     "scripts": ["background/background.ts"]

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -6,6 +6,9 @@ import store from "../store";
 const whitelistedChannelsList = $(
   "#whitelisted-channels-list"
 ) as HTMLUListElement;
+const disableVodRedirectCheckbox = $(
+  "#disable-vod-redirect-checkbox"
+) as HTMLInputElement;
 const removeTokenFromRequestsCheckbox = $(
   "#remove-token-checkbox"
 ) as HTMLInputElement;
@@ -17,14 +20,16 @@ if (store.readyState === "complete") main();
 else store.addEventListener("load", main);
 
 function main() {
-  let whitelistedChannels = store.state.whitelistedChannels;
-  let removeTokenFromRequests = store.state.removeTokenFromRequests;
-  let servers = store.state.servers;
+  const whitelistedChannels = store.state.whitelistedChannels;
+  const disableVodRedirect = store.state.disableVodRedirect;
+  const removeTokenFromRequests = store.state.removeTokenFromRequests;
+  const servers = store.state.servers;
 
   for (const whitelistedChannel of whitelistedChannels) {
     appendWhitelistedChannel(whitelistedChannel);
   }
   appendAddChannelInput();
+  disableVodRedirectCheckbox.checked = disableVodRedirect;
   removeTokenFromRequestsCheckbox.checked = removeTokenFromRequests;
   if (servers.length && servers[0] != "https://api.ttv.lol") {
     serverSelect.value = "local";
@@ -92,6 +97,11 @@ function appendAddChannelInput() {
   li.appendChild(input);
   whitelistedChannelsList.appendChild(li);
 }
+
+disableVodRedirectCheckbox.addEventListener("change", e => {
+  const { checked } = e.target as HTMLInputElement;
+  store.state.disableVodRedirect = checked;
+});
 
 removeTokenFromRequestsCheckbox.addEventListener("change", e => {
   const { checked } = e.target as HTMLInputElement;

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -2,6 +2,7 @@ import isPrivateIP from "private-ip";
 import $ from "../common/ts/$";
 import store from "../store";
 
+//#region HTML Elements
 const whitelistedChannelsList = $(
   "#whitelisted-channels-list"
 ) as HTMLUListElement;
@@ -10,8 +11,12 @@ const removeTokenFromRequestsCheckbox = $(
 ) as HTMLInputElement;
 const serverSelect = $("#server-select") as HTMLSelectElement;
 const localServerInput = $("#local-server-input") as HTMLInputElement;
+//#endregion
 
-store.addEventListener("load", () => {
+if (store.readyState === "complete") main();
+else store.addEventListener("load", main);
+
+function main() {
   let whitelistedChannels = store.state.whitelistedChannels;
   let removeTokenFromRequests = store.state.removeTokenFromRequests;
   let servers = store.state.servers;
@@ -26,7 +31,7 @@ store.addEventListener("load", () => {
     localServerInput.value = servers[0];
     localServerInput.style.display = "inline-block";
   }
-});
+}
 
 function appendWhitelistedChannel(whitelistedChannel: string) {
   const li = document.createElement("li");

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -9,9 +9,6 @@ const whitelistedChannelsList = $(
 const disableVodRedirectCheckbox = $(
   "#disable-vod-redirect-checkbox"
 ) as HTMLInputElement;
-const removeTokenFromRequestsCheckbox = $(
-  "#remove-token-checkbox"
-) as HTMLInputElement;
 const serverSelect = $("#server-select") as HTMLSelectElement;
 const localServerInput = $("#local-server-input") as HTMLInputElement;
 //#endregion
@@ -22,7 +19,6 @@ else store.addEventListener("load", main);
 function main() {
   const whitelistedChannels = store.state.whitelistedChannels;
   const disableVodRedirect = store.state.disableVodRedirect;
-  const removeTokenFromRequests = store.state.removeTokenFromRequests;
   const servers = store.state.servers;
 
   for (const whitelistedChannel of whitelistedChannels) {
@@ -30,7 +26,6 @@ function main() {
   }
   appendAddChannelInput();
   disableVodRedirectCheckbox.checked = disableVodRedirect;
-  removeTokenFromRequestsCheckbox.checked = removeTokenFromRequests;
   if (servers.length && servers[0] != "https://api.ttv.lol") {
     serverSelect.value = "local";
     localServerInput.value = servers[0];
@@ -99,13 +94,19 @@ function appendAddChannelInput() {
 }
 
 disableVodRedirectCheckbox.addEventListener("change", e => {
-  const { checked } = e.target as HTMLInputElement;
-  store.state.disableVodRedirect = checked;
-});
-
-removeTokenFromRequestsCheckbox.addEventListener("change", e => {
-  const { checked } = e.target as HTMLInputElement;
-  store.state.removeTokenFromRequests = checked;
+  const checkbox = e.target as HTMLInputElement;
+  if (checkbox.checked) {
+    store.state.disableVodRedirect = checkbox.checked;
+  } else {
+    const consent = confirm(
+      "Are you sure?\n\nYour Twitch token (containing sensitive information) will be sent to TTV LOL's API server when watching VODs."
+    );
+    if (consent) {
+      store.state.disableVodRedirect = checkbox.checked;
+    } else {
+      checkbox.checked = true;
+    }
+  }
 });
 
 function setLocalServer(server: string) {

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -1,6 +1,6 @@
+import isPrivateIP from "private-ip";
 import $ from "../common/ts/$";
 import store from "../store";
-import isPrivateIP from "private-ip";
 
 const whitelistedChannelsList = $(
   "#whitelisted-channels-list"

--- a/src/options/page.html
+++ b/src/options/page.html
@@ -44,24 +44,6 @@
               from VODs, this option is enabled by default.
             </small>
           </li>
-          <li>
-            <input
-              type="checkbox"
-              name="remove-token-checkbox"
-              id="remove-token-checkbox"
-            />
-            <label for="remove-token-checkbox">
-              Remove token from API requests
-            </label>
-            <br />
-            <small>
-              TTV LOL PRO removes <code>device_id</code>, <code>user_id</code>,
-              and <code>user_ip</code> token properties for live streams by
-              default. Enabling this option disables VOD proxying (because TTV
-              LOL's API requires your Twitch token for VODs) and might make some
-              stream quality options unavailable.
-            </small>
-          </li>
         </ul>
       </section>
 

--- a/src/options/page.html
+++ b/src/options/page.html
@@ -29,19 +29,37 @@
           <li>
             <input
               type="checkbox"
+              name="disable-vod-redirect-checkbox"
+              id="disable-vod-redirect-checkbox"
+            />
+            <label for="disable-vod-redirect-checkbox">
+              Disable VOD proxying
+            </label>
+            <span class="tag">Recommended</span>
+            <br />
+            <small>
+              TTV LOL's API requires your Twitch token (containing sensitive
+              information) to remove ads from VODs. To protect your privacy, and
+              since most ad blockers (like uBlock Origin) already remove ads
+              from VODs, this option is enabled by default.
+            </small>
+          </li>
+          <li>
+            <input
+              type="checkbox"
               name="remove-token-checkbox"
               id="remove-token-checkbox"
             />
             <label for="remove-token-checkbox">
               Remove token from API requests
             </label>
-            <span class="tag">Recommended for streamers</span>
             <br />
             <small>
               TTV LOL PRO removes <code>device_id</code>, <code>user_id</code>,
-              and <code>user_ip</code> parameters for live streams by default.
-              Since TTV LOL's API requires the token signature for VODs, VODs
-              will not be proxied if you enable this option.
+              and <code>user_ip</code> token properties for live streams by
+              default. Since TTV LOL's API requires your Twitch token for VODs,
+              VODs will not be proxied if you enable this option. Some stream
+              qualities might be unavailable when using this option.
             </small>
           </li>
         </ul>

--- a/src/options/page.html
+++ b/src/options/page.html
@@ -57,9 +57,9 @@
             <small>
               TTV LOL PRO removes <code>device_id</code>, <code>user_id</code>,
               and <code>user_ip</code> token properties for live streams by
-              default. Since TTV LOL's API requires your Twitch token for VODs,
-              VODs will not be proxied if you enable this option. Some stream
-              qualities might be unavailable when using this option.
+              default. Enabling this option disables VOD proxying (because TTV
+              LOL's API requires your Twitch token for VODs) and might make some
+              stream quality options unavailable.
             </small>
           </li>
         </ul>

--- a/src/options/style.css
+++ b/src/options/style.css
@@ -15,12 +15,12 @@
 }
 
 body {
-  accent-color: var(--brand-color);
+  margin: 1.5rem;
   background-color: var(--ui-background-color);
   color: var(--text-primary);
-  font-family: var(--font-primary);
-  margin: 1.5rem;
+  accent-color: var(--brand-color);
   font-size: 100%;
+  font-family: var(--font-primary);
 }
 
 ::-moz-selection,
@@ -31,12 +31,12 @@ body {
 
 input[type="text"],
 select {
-  background-color: var(--input-background-color);
-  color: var(--input-text-primary);
-  border: 1px solid var(--input-border-color);
-  border-radius: 6px;
   height: 30px;
   padding: 0 0.65rem;
+  border: 1px solid var(--input-border-color);
+  border-radius: 6px;
+  background-color: var(--input-background-color);
+  color: var(--input-text-primary);
   vertical-align: middle;
 }
 
@@ -65,14 +65,14 @@ section > h2 {
 }
 
 .tag {
+  margin-left: 0.25rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
   background-color: var(--input-border-color);
   color: var(--input-text-primary);
-  border-radius: 4px;
-  font-size: 0.65rem;
   font-weight: 600;
+  font-size: 0.65rem;
   text-transform: uppercase;
-  padding: 0.25rem 0.5rem;
-  margin-left: 0.25rem;
 }
 
 small {
@@ -81,8 +81,8 @@ small {
 }
 
 #whitelisted-channels-list > li > input {
-  margin-bottom: 0.25rem;
   min-width: 300px;
+  margin-bottom: 0.25rem;
 }
 
 .options-list {

--- a/src/options/style.css
+++ b/src/options/style.css
@@ -91,6 +91,7 @@ small {
 
 .options-list > li {
   position: relative;
+  margin-bottom: 1rem;
 }
 
 .options-list > li > input[type="checkbox"] {

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -21,7 +21,7 @@ store.addEventListener("load", async () => {
 
   const match = TWITCH_URL_REGEX.exec(activeTab.url);
   if (!match) return;
-  const [_, streamId] = match;
+  const [, streamId] = match;
   if (!streamId) return;
 
   setStreamStatusElement(streamId);

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -32,7 +32,7 @@ store.addEventListener("load", async () => {
 function setStreamStatusElement(streamId: string) {
   const streamIdLower = streamId.toLowerCase();
   const status = store.state.streamStatuses[streamIdLower];
-  if (status != null) {
+  if (status) {
     streamStatusElement.style.display = "flex";
     if (status.redirected) {
       redirectedElement.classList.remove("error");
@@ -60,7 +60,7 @@ function setStreamStatusElement(streamId: string) {
 function setWhitelistToggleElement(streamId: string) {
   const streamIdLower = streamId.toLowerCase();
   const status = store.state.streamStatuses[streamIdLower];
-  if (status != null) {
+  if (status) {
     whitelistToggle.checked =
       store.state.whitelistedChannels.includes(streamId);
     whitelistToggle.addEventListener("change", e => {

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -14,7 +14,10 @@ const whitelistToggle = $("#whitelist-toggle") as HTMLInputElement;
 const whitelistToggleLabel = $("#whitelist-toggle-label") as HTMLLabelElement;
 //#endregion
 
-store.addEventListener("load", async () => {
+if (store.readyState === "complete") main();
+else store.addEventListener("load", main);
+
+async function main() {
   const tabs = await browser.tabs.query({ active: true, currentWindow: true });
   const activeTab = tabs[0];
   if (!activeTab || !activeTab.url) return;
@@ -27,7 +30,7 @@ store.addEventListener("load", async () => {
   setStreamStatusElement(streamId);
   setWhitelistToggleElement(streamId);
   store.addEventListener("change", () => setStreamStatusElement(streamId));
-});
+}
 
 function setStreamStatusElement(streamId: string) {
   const streamIdLower = streamId.toLowerCase();

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -51,7 +51,7 @@ function setStreamStatusElement(streamId: string) {
       reasonElement.style.display = "none";
     }
     if (status.proxyCountry) {
-      proxyCountryElement.textContent = `Proxy country: ${status.proxyCountry}`;
+      proxyCountryElement.textContent = `Proxy country (Beta): ${status.proxyCountry}`;
     } else {
       proxyCountryElement.style.display = "none";
     }

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -1,6 +1,6 @@
-import { TWITCH_URL_REGEX } from "../common/ts/regexes";
-import $ from "../common/ts/$";
 import browser from "webextension-polyfill";
+import $ from "../common/ts/$";
+import { TWITCH_URL_REGEX } from "../common/ts/regexes";
 import store from "../store";
 
 //#region HTML Elements

--- a/src/popup/style.css
+++ b/src/popup/style.css
@@ -58,7 +58,7 @@ body {
 .icon {
   margin-bottom: -3px;
 }
-.buton-text {
+.button-text {
   margin-bottom: 10px;
 }
 .button-arrow .arrow-head {
@@ -80,6 +80,9 @@ body {
 
 #stream-status {
   background-color: #202127;
+  border-bottom: 1px solid hsl(210, 4%, 25%);
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
   border-radius: 8px;
   display: none;
   gap: 7px;
@@ -110,8 +113,10 @@ body {
 #whitelist-toggle-wrapper {
   background-color: #202127;
   border-radius: 8px;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
   display: none;
-  margin-top: 5px;
+  margin-top: 0;
   margin-bottom: 0;
   margin-left: 30px;
   margin-right: 30px;
@@ -124,7 +129,7 @@ body {
   display: none;
 }
 #whitelist-toggle:checked + #whitelist-toggle-label {
-  color: #2997ff;
+  color: #baaadb;
 }
 #whitelist-toggle-label {
   cursor: pointer;
@@ -132,5 +137,5 @@ body {
   font-size: 11pt;
   font-weight: bold;
   margin: 0;
-  padding: 8px 15px;
+  padding: 10px 15px;
 }

--- a/src/popup/style.css
+++ b/src/popup/style.css
@@ -1,27 +1,27 @@
 html {
+  -webkit-font-smoothing: antialiased;
   background: #151619;
   color: #c9cbcd;
   font-family: "Open Sans", "Segoe UI", sans-serif;
-  -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
 }
 
 body {
-  font-size: 100%;
-  margin-left: auto;
-  margin-right: auto;
   width: 300px;
+  margin-right: auto;
+  margin-left: auto;
+  font-size: 100%;
 }
 
 .container {
-  text-align: center;
   padding-bottom: 10px;
+  text-align: center;
 }
 
 .logo-wrapper {
-  background-color: #202127;
-  border-radius: 8px;
   margin: 30px 30px 15px 30px;
+  border-radius: 8px;
+  background-color: #202127;
 }
 
 .button-group {
@@ -31,10 +31,10 @@ body {
 }
 
 .button {
+  padding: 10px 20px;
   border-radius: 6px;
   color: #c3c4ca;
   font-weight: bold;
-  padding: 10px 20px;
   text-decoration: none;
   transition: all 150ms ease-in-out;
 }
@@ -45,15 +45,15 @@ body {
   margin-left: 15px;
 }
 .discord {
-  overflow: visible;
-  margin-right: 3px;
   display: inline-block;
+  margin-right: 3px;
+  overflow: visible;
 }
 .button-arrow .arrow-icon {
-  overflow: visible;
-  margin-left: 3px;
-  margin-bottom: -2px;
   width: 8px;
+  margin-bottom: -2px;
+  margin-left: 3px;
+  overflow: visible;
 }
 .icon {
   margin-bottom: -3px;
@@ -66,28 +66,28 @@ body {
   transition: transform 150ms ease-in-out;
 }
 .button-arrow .arrow-body {
-  opacity: 0;
   transform: scaleX(1);
+  opacity: 0;
   transition: transform 150ms ease-in-out, opacity 150ms ease-in-out;
 }
 .button-arrow:hover .arrow-head {
   transform: translateX(3px);
 }
 .button-arrow:hover .arrow-body {
-  opacity: 1;
   transform: scaleX(2);
+  opacity: 1;
 }
 
 #stream-status {
-  background-color: #202127;
-  border-bottom: 1px solid hsl(210, 4%, 25%);
-  border-bottom-left-radius: 0;
-  border-bottom-right-radius: 0;
-  border-radius: 8px;
   display: none;
-  gap: 7px;
   margin: 0 30px;
   padding: 15px;
+  gap: 7px;
+  border-bottom: 1px solid hsl(210, 4%, 25%);
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0;
+  border-radius: 8px;
+  background-color: #202127;
   text-align: start;
 }
 #stream-status #redirected.success {
@@ -105,21 +105,21 @@ body {
 }
 #stream-status #proxy-country {
   display: inline-block;
-  font-size: 7pt;
   margin-top: 5px;
+  font-size: 7pt;
   opacity: 0.6;
 }
 
 #whitelist-toggle-wrapper {
-  background-color: #202127;
-  border-radius: 8px;
-  border-top-left-radius: 0;
-  border-top-right-radius: 0;
   display: none;
   margin-top: 0;
+  margin-right: 30px;
   margin-bottom: 0;
   margin-left: 30px;
-  margin-right: 30px;
+  border-radius: 8px;
+  border-top-right-radius: 0;
+  border-top-left-radius: 0;
+  background-color: #202127;
   transition: background-color 150ms ease-in-out;
 }
 #whitelist-toggle-wrapper:hover {
@@ -132,10 +132,10 @@ body {
   color: #baaadb;
 }
 #whitelist-toggle-label {
-  cursor: pointer;
   display: block;
-  font-size: 11pt;
-  font-weight: bold;
   margin: 0;
   padding: 10px 15px;
+  font-weight: bold;
+  font-size: 11pt;
+  cursor: pointer;
 }

--- a/src/store/getDefaultState.ts
+++ b/src/store/getDefaultState.ts
@@ -2,6 +2,7 @@ import { State } from "./types";
 
 export default function getDefaultState() {
   return {
+    disableVodRedirect: true,
     removeTokenFromRequests: false,
     servers: ["https://api.ttv.lol"],
     streamStatuses: {},

--- a/src/store/getDefaultState.ts
+++ b/src/store/getDefaultState.ts
@@ -1,0 +1,10 @@
+import { State } from "./types";
+
+export default function getDefaultState() {
+  return {
+    removeTokenFromRequests: false,
+    servers: ["https://api.ttv.lol"],
+    streamStatuses: {},
+    whitelistedChannels: [],
+  } as State;
+}

--- a/src/store/getDefaultState.ts
+++ b/src/store/getDefaultState.ts
@@ -3,7 +3,6 @@ import { State } from "./types";
 export default function getDefaultState() {
   return {
     disableVodRedirect: true,
-    removeTokenFromRequests: false,
     servers: ["https://api.ttv.lol"],
     streamStatuses: {},
     whitelistedChannels: [],

--- a/src/store/handlers/getPropertyHandler.ts
+++ b/src/store/handlers/getPropertyHandler.ts
@@ -1,0 +1,52 @@
+import browser from "webextension-polyfill";
+import { ProxyFlags, State, StorageArea } from "../types";
+import { toRaw } from "../utils";
+
+export default function getPropertyHandler(
+  areaName: StorageArea,
+  state: State,
+  property: string | symbol
+) {
+  const propertyHandler: ProxyHandler<Record<string | symbol, any>> = {
+    defineProperty: (propertyObj, subproperty, subpropertyDescriptor) => {
+      const rawSubpropertyDescriptor = toRaw(subpropertyDescriptor);
+      propertyObj[subproperty] = rawSubpropertyDescriptor;
+      browser.storage[areaName]
+        .set({ [property]: state[property] })
+        .catch(console.error);
+      return true;
+    },
+    deleteProperty: (propertyObj, subproperty) => {
+      delete propertyObj[subproperty];
+      browser.storage[areaName]
+        .set({ [property]: state[property] })
+        .catch(console.error);
+      return true;
+    },
+    get: (propertyObj, subproperty) => {
+      if (subproperty === ProxyFlags.IS_PROXY) return true;
+      if (subproperty === ProxyFlags.RAW) return propertyObj;
+      const subpropertyValue = propertyObj[subproperty];
+      const containsObjects = (parent: object) =>
+        Object.values(parent).some(
+          childValue => typeof childValue === "object" && childValue !== null
+        );
+      if (
+        typeof subpropertyValue === "object" &&
+        subpropertyValue !== null &&
+        containsObjects(subpropertyValue)
+      ) {
+        return new Proxy(subpropertyValue, propertyHandler);
+      } else return subpropertyValue;
+    },
+    set: (propertyObj, subproperty, subpropertyValue) => {
+      const rawSubpropertyValue = toRaw(subpropertyValue);
+      propertyObj[subproperty] = rawSubpropertyValue;
+      browser.storage[areaName]
+        .set({ [property]: state[property] })
+        .catch(console.error);
+      return true;
+    },
+  };
+  return propertyHandler;
+}

--- a/src/store/handlers/getStateHandler.ts
+++ b/src/store/handlers/getStateHandler.ts
@@ -1,0 +1,41 @@
+import browser from "webextension-polyfill";
+import { ProxyFlags, State, StorageArea } from "../types";
+import { toRaw } from "../utils";
+import getPropertyHandler from "./getPropertyHandler";
+
+export default function getStateHandler(areaName: StorageArea, state: State) {
+  const stateHandler: ProxyHandler<State> = {
+    defineProperty: (target, key, descriptor) => {
+      const rawDescriptor = toRaw(descriptor);
+      target[key] = rawDescriptor;
+      browser.storage[areaName]
+        .set({ [key]: rawDescriptor })
+        .catch(console.error);
+      return true;
+    },
+    deleteProperty: (target, property) => {
+      delete target[property];
+      browser.storage[areaName]
+        .remove(property.toString())
+        .catch(console.error);
+      return true;
+    },
+    get: (target, property) => {
+      if (property === ProxyFlags.IS_PROXY) return true;
+      if (property === ProxyFlags.RAW) return target;
+      if (typeof target[property] === "object" && target[property] !== null) {
+        const propertyHandler = getPropertyHandler(areaName, state, property);
+        return new Proxy(target[property], propertyHandler);
+      } else return target[property];
+    },
+    set: (target, property, value) => {
+      const rawValue = toRaw(value);
+      target[property] = rawValue;
+      browser.storage[areaName]
+        .set({ [property]: rawValue })
+        .catch(console.error);
+      return true;
+    },
+  };
+  return stateHandler;
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -130,7 +130,7 @@ async function init() {
   const storage = await browser.storage[areaName].get(null);
   // Set default values for undefined properties.
   for (const [key, value] of Object.entries(getDefaultState())) {
-    if (storage[key] == null) storage[key] = value;
+    if (!storage[key]) storage[key] = value;
   }
   // Update state.
   for (const [key, value] of Object.entries(storage)) {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -16,7 +16,7 @@ const getDefaultState = (): State => ({
 });
 
 function isProxy(value: any) {
-  return value != null && value[ProxyFlags.IS_PROXY];
+  return value && value[ProxyFlags.IS_PROXY];
 }
 function toRaw(value: any) {
   if (isProxy(value)) return value[ProxyFlags.RAW];

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,142 +1,65 @@
-// TODO: Refactor to use a Store class with exported instances for each area.
-
 import browser from "webextension-polyfill";
-import { ProxyFlags, State } from "../types";
+import getDefaultState from "./getDefaultState";
+import getStateHandler from "./handlers/getStateHandler";
+import { EventType, ReadyState, State, StorageArea } from "./types";
 
-type StorageArea = "local" | "managed" | "session" | "sync";
-type EventType = "load" | "change";
+class Store {
+  private _state = getDefaultState();
+  private listenersByEvent: Record<string, Function[]> = {};
 
-const areaName: StorageArea = "local";
-const listenersByEvent: { [type: string]: Function[] } = {};
-const getDefaultState = (): State => ({
-  removeTokenFromRequests: false,
-  servers: ["https://api.ttv.lol"],
-  streamStatuses: {},
-  whitelistedChannels: [],
-});
+  areaName: StorageArea;
+  readyState: ReadyState = "loading";
+  state: State; // Proxy
 
-function isProxy(value: any) {
-  return value && value[ProxyFlags.IS_PROXY];
-}
-function toRaw(value: any) {
-  if (isProxy(value)) return value[ProxyFlags.RAW];
-  if (typeof value === "object" && value !== null) {
-    for (let key in value) {
-      value[key] = toRaw(value[key]);
+  constructor(areaName: StorageArea) {
+    this.areaName = areaName;
+    const stateHandler = getStateHandler(this.areaName, this._state);
+    const stateProxy = new Proxy(this._state, stateHandler);
+    this.state = stateProxy;
+    browser.storage.onChanged.addListener((changes, area) => {
+      if (area !== this.areaName) return;
+      for (const [key, { newValue }] of Object.entries(changes)) {
+        this._state[key] = newValue;
+      }
+      this.dispatchEvent("change");
+    });
+    this.init().then(() => {
+      this.readyState = "complete";
+      this.dispatchEvent("load");
+    });
+  }
+
+  async init() {
+    // Retrieve the entire storage contents.
+    // See https://stackoverflow.com/questions/18150774/get-all-keys-from-chrome-storage
+    const storage = await browser.storage[this.areaName].get(null);
+    // Set default values for undefined properties.
+    for (const [key, value] of Object.entries(getDefaultState())) {
+      if (!storage[key]) storage[key] = value;
     }
-    return value;
-  } else return value;
-}
-
-const state = getDefaultState();
-const handler: ProxyHandler<State> = {
-  defineProperty: (target, key, descriptor) => {
-    const rawDescriptor = toRaw(descriptor);
-    target[key] = rawDescriptor;
-    browser.storage[areaName]
-      .set({ [key]: rawDescriptor })
-      .catch(console.error);
-    return true;
-  },
-  deleteProperty: (target, property) => {
-    delete target[property];
-    browser.storage[areaName].remove(property.toString()).catch(console.error);
-    return true;
-  },
-  get: (target, property) => {
-    if (property === ProxyFlags.IS_PROXY) return true;
-    if (property === ProxyFlags.RAW) return target;
-    if (typeof target[property] === "object" && target[property] !== null) {
-      const propertyHandler: ProxyHandler<{ [key: string | symbol]: any }> = {
-        defineProperty: (propertyObj, subproperty, subpropertyDescriptor) => {
-          const rawSubpropertyDescriptor = toRaw(subpropertyDescriptor);
-          propertyObj[subproperty] = rawSubpropertyDescriptor;
-          browser.storage[areaName]
-            .set({ [property]: state[property] })
-            .catch(console.error);
-          return true;
-        },
-        deleteProperty: (propertyObj, subproperty) => {
-          delete propertyObj[subproperty];
-          browser.storage[areaName]
-            .set({ [property]: state[property] })
-            .catch(console.error);
-          return true;
-        },
-        get: (propertyObj, subproperty) => {
-          if (subproperty === ProxyFlags.IS_PROXY) return true;
-          if (subproperty === ProxyFlags.RAW) return propertyObj;
-          const subpropertyValue = propertyObj[subproperty];
-          const containsObjects = (parent: object) =>
-            Object.values(parent).some(
-              childValue =>
-                typeof childValue === "object" && childValue !== null
-            );
-          if (
-            typeof subpropertyValue === "object" &&
-            subpropertyValue !== null &&
-            containsObjects(subpropertyValue)
-          ) {
-            return new Proxy(subpropertyValue, propertyHandler);
-          } else return subpropertyValue;
-        },
-        set: (propertyObj, subproperty, subpropertyValue) => {
-          const rawSubpropertyValue = toRaw(subpropertyValue);
-          propertyObj[subproperty] = rawSubpropertyValue;
-          browser.storage[areaName]
-            .set({ [property]: state[property] })
-            .catch(console.error);
-          return true;
-        },
-      };
-      return new Proxy(target[property], propertyHandler);
-    } else return target[property];
-  },
-  set: (target, property, value) => {
-    const rawValue = toRaw(value);
-    target[property] = rawValue;
-    browser.storage[areaName]
-      .set({ [property]: rawValue })
-      .catch(console.error);
-    return true;
-  },
-};
-const stateProxy = new Proxy(state, handler);
-browser.storage.onChanged.addListener((changes, area) => {
-  if (area !== areaName) return;
-  for (const [key, { newValue }] of Object.entries(changes)) {
-    state[key] = newValue;
+    // Update state.
+    for (const [key, value] of Object.entries(storage)) {
+      this._state[key] = value;
+    }
   }
-  dispatchEvent("change");
-});
 
-function addEventListener(type: EventType, listener: Function) {
-  if (!listenersByEvent[type]) listenersByEvent[type] = [];
-  listenersByEvent[type].push(listener);
-}
-function removeEventListener(type: EventType, listener: Function) {
-  if (!listenersByEvent[type]) return;
-  const index = listenersByEvent[type].findIndex(x => x === listener);
-  if (index !== -1) listenersByEvent[type].splice(index, 1);
-}
-function dispatchEvent(type: EventType) {
-  const listeners = listenersByEvent[type] || [];
-  listeners.forEach(listener => listener());
-}
-
-async function init() {
-  // Retrieve the entire storage contents.
-  // See https://stackoverflow.com/questions/18150774/get-all-keys-from-chrome-storage
-  const storage = await browser.storage[areaName].get(null);
-  // Set default values for undefined properties.
-  for (const [key, value] of Object.entries(getDefaultState())) {
-    if (!storage[key]) storage[key] = value;
+  addEventListener(type: EventType, listener: Function) {
+    if (!this.listenersByEvent[type]) this.listenersByEvent[type] = [];
+    this.listenersByEvent[type].push(listener);
   }
-  // Update state.
-  for (const [key, value] of Object.entries(storage)) {
-    state[key] = value;
+
+  removeEventListener(type: EventType, listener: Function) {
+    if (!this.listenersByEvent[type]) return;
+    const index = this.listenersByEvent[type].findIndex(x => x === listener);
+    if (index !== -1) this.listenersByEvent[type].splice(index, 1);
+  }
+
+  dispatchEvent(type: EventType) {
+    const listeners = this.listenersByEvent[type] || [];
+    listeners.forEach(listener => listener());
   }
 }
-init().then(() => dispatchEvent("load"));
 
-export default { state: stateProxy, addEventListener, removeEventListener };
+const store = new Store("local");
+
+export default store;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -5,7 +5,7 @@ import { EventType, ReadyState, State, StorageArea } from "./types";
 
 class Store {
   private _state = getDefaultState();
-  private listenersByEvent: Record<string, Function[]> = {};
+  private _listenersByEvent: Record<string, Function[]> = {};
 
   areaName: StorageArea;
   readyState: ReadyState = "loading";
@@ -23,13 +23,13 @@ class Store {
       }
       this.dispatchEvent("change");
     });
-    this.init().then(() => {
+    this._init().then(() => {
       this.readyState = "complete";
       this.dispatchEvent("load");
     });
   }
 
-  async init() {
+  private async _init() {
     // Retrieve the entire storage contents.
     // See https://stackoverflow.com/questions/18150774/get-all-keys-from-chrome-storage
     const storage = await browser.storage[this.areaName].get(null);
@@ -44,18 +44,18 @@ class Store {
   }
 
   addEventListener(type: EventType, listener: Function) {
-    if (!this.listenersByEvent[type]) this.listenersByEvent[type] = [];
-    this.listenersByEvent[type].push(listener);
+    if (!this._listenersByEvent[type]) this._listenersByEvent[type] = [];
+    this._listenersByEvent[type].push(listener);
   }
 
   removeEventListener(type: EventType, listener: Function) {
-    if (!this.listenersByEvent[type]) return;
-    const index = this.listenersByEvent[type].findIndex(x => x === listener);
-    if (index !== -1) this.listenersByEvent[type].splice(index, 1);
+    if (!this._listenersByEvent[type]) return;
+    const index = this._listenersByEvent[type].findIndex(x => x === listener);
+    if (index !== -1) this._listenersByEvent[type].splice(index, 1);
   }
 
   dispatchEvent(type: EventType) {
-    const listeners = this.listenersByEvent[type] || [];
+    const listeners = this._listenersByEvent[type] || [];
     listeners.forEach(listener => listener());
   }
 }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -35,7 +35,7 @@ class Store {
     const storage = await browser.storage[this.areaName].get(null);
     // Set default values for undefined properties.
     for (const [key, value] of Object.entries(getDefaultState())) {
-      if (!storage[key]) storage[key] = value;
+      if (storage[key] == null) storage[key] = value;
     }
     // Update state.
     for (const [key, value] of Object.entries(storage)) {

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -6,7 +6,6 @@ export type StorageArea = "local" | "managed" | "session" | "sync";
 
 export interface State {
   disableVodRedirect: boolean;
-  removeTokenFromRequests: boolean;
   servers: string[];
   streamStatuses: Record<string, StreamStatus>;
   whitelistedChannels: string[];

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -1,0 +1,17 @@
+import { StreamStatus } from "../types";
+
+export type EventType = "load" | "change";
+export type ReadyState = "loading" | "complete";
+export type StorageArea = "local" | "managed" | "session" | "sync";
+
+export interface State {
+  removeTokenFromRequests: boolean;
+  servers: string[];
+  streamStatuses: Record<string, StreamStatus>;
+  whitelistedChannels: string[];
+}
+
+export const enum ProxyFlags {
+  IS_PROXY = "__isProxy",
+  RAW = "__raw",
+}

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -5,6 +5,7 @@ export type ReadyState = "loading" | "complete";
 export type StorageArea = "local" | "managed" | "session" | "sync";
 
 export interface State {
+  disableVodRedirect: boolean;
   removeTokenFromRequests: boolean;
   servers: string[];
   streamStatuses: Record<string, StreamStatus>;

--- a/src/store/utils.ts
+++ b/src/store/utils.ts
@@ -1,0 +1,15 @@
+import { ProxyFlags } from "./types";
+
+export function isProxy(value: any) {
+  return value && value[ProxyFlags.IS_PROXY];
+}
+
+export function toRaw(value: any) {
+  if (isProxy(value)) return value[ProxyFlags.RAW];
+  if (typeof value === "object" && value !== null) {
+    for (let key in value) {
+      value[key] = toRaw(value[key]);
+    }
+  }
+  return value;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,16 +43,6 @@ export interface Token {
   vod_id?: number;
 }
 
-export const enum ProxyFlags {
-  IS_PROXY = "__isProxy",
-  RAW = "__raw",
-}
-
-export interface StreamStatusError {
-  timestamp: number;
-  status: number;
-}
-
 export interface StreamStatus {
   redirected: boolean;
   reason: string;
@@ -60,9 +50,7 @@ export interface StreamStatus {
   proxyCountry?: string;
 }
 
-export interface State {
-  removeTokenFromRequests: boolean;
-  servers: string[];
-  streamStatuses: Record<string, StreamStatus>;
-  whitelistedChannels: string[];
+export interface StreamStatusError {
+  timestamp: number;
+  status: number;
 }


### PR DESCRIPTION
- **Improved default privacy configuration (Fix #20)**
  - Live streams
    - <ins>Before</ins>: `device_id`, `user_id`, and `user_ip` token properties are removed by default
    - <ins>Now</ins>: Token is completely removed from requests
  - VODs
    - <ins>Before</ins>: Token was sent to TTV LOL's API by default *(because TTV LOL's API requires it for VODs)*
    - <ins>Now</ins>: VOD proxying is disabled by default. User must enable VOD proxying in Options and confirm to have token sent to TTV LOL's API when watching VODs
- _(Firefox only)_ **Added "(Beta)" tag to Proxy country in Popup since feature sometimes seems unreliable**
- **Minor UI adjustments in Popup**
- **Refactored code of `store` module, improving its robustness**
- **Upgrade dependencies**
- **Added a few more linter rules**
