### PR TITLE
Add permission to use player and embed links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4286,7 +4286,8 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.3.1.tgz",
       "integrity": "sha512-fBffmak0bPAnyqc/HO8C3n2sHrp9wcqQz6ES9koRF2/mLOVAx9zIQ3Y7R29sYCteTPqMCwns4WYQoCX91Xl3+w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "css-select": {
       "version": "4.3.0",
@@ -4825,13 +4826,15 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-6.0.0.tgz",
       "integrity": "sha512-FPX16mQLyEjLzEuuJtxA8X3ejDLNGGEG503d2YGZR5Ask1SpDN8KmZUMpzCvyalWRywAn1n1VOA5dcqfCLo5rg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-scss": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.6.tgz",
       "integrity": "sha512-rLDPhJY4z/i4nVFZ27j9GqLxj1pwxE80eAzUNRMXtcpipFYIeowerzBgG3yJhMtObGEXidtIgbUpQ3eLDsf5OQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-value-parser": {
       "version": "4.2.0",
@@ -4900,7 +4903,8 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-3.2.2.tgz",
       "integrity": "sha512-e97lE6odGSiHonHJMTYC0q0iLXQyw0u5z/PJpvP/3vRy6/Zi9kLBwFAbEGjDzIowpjQv8b+J04PDamoUSQbzGA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "promise-polyfill": {
       "version": "8.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4286,8 +4286,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.3.1.tgz",
       "integrity": "sha512-fBffmak0bPAnyqc/HO8C3n2sHrp9wcqQz6ES9koRF2/mLOVAx9zIQ3Y7R29sYCteTPqMCwns4WYQoCX91Xl3+w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "css-select": {
       "version": "4.3.0",
@@ -4826,15 +4825,13 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-6.0.0.tgz",
       "integrity": "sha512-FPX16mQLyEjLzEuuJtxA8X3ejDLNGGEG503d2YGZR5Ask1SpDN8KmZUMpzCvyalWRywAn1n1VOA5dcqfCLo5rg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-scss": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.6.tgz",
       "integrity": "sha512-rLDPhJY4z/i4nVFZ27j9GqLxj1pwxE80eAzUNRMXtcpipFYIeowerzBgG3yJhMtObGEXidtIgbUpQ3eLDsf5OQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-value-parser": {
       "version": "4.2.0",
@@ -4903,8 +4900,7 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-3.2.2.tgz",
       "integrity": "sha512-e97lE6odGSiHonHJMTYC0q0iLXQyw0u5z/PJpvP/3vRy6/Zi9kLBwFAbEGjDzIowpjQv8b+J04PDamoUSQbzGA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "promise-polyfill": {
       "version": "8.3.0",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -41,7 +41,9 @@
     "https://*.ttvnw.net/*",
     "https://api.ttv.lol/*",
     "https://www.twitch.tv/*",
-    "https://m.twitch.tv/*"
+    "https://m.twitch.tv/*",
+    "https://player.twitch.tv/*",
+    "https://embed.twitch.tv/*"
   ],
   "update_url": "https://younesaassila.github.io/ttv-lol-pro/updates.xml"
 }


### PR DESCRIPTION
sites like https://multitwitch.live/ uses embeds
https://lazygoat.tv/ uses player links
by adding permission this blocks pre-roll and mid-roll ads on these sites
as mentioned in https://github.com/younesaassila/ttv-lol-pro/discussions/94#discussioncomment-5143806
this doesn't handle some of the more complex features such as  "stream status"/"Reset player on midroll".
But I think the base proxy functionality is useful enough on it's own for alternative sites
also addresses #95