### PR TITLE
Improve passport laissez-passer explanation

### DIFF
--- a/src/options/page.html
+++ b/src/options/page.html
@@ -69,12 +69,28 @@
                   Only enable this option if you are experiencing issues with
                   TTV LOL PRO's passport!
                 </b>
+                <br />
+                </small>
+                <small>
                 <b>
-                  WARNING: Enabling this option while proxying thru another country could enable features that are not enabled on your country (such as Predictions, Prime Subscriptions, Currency Changes and others). You accept full responsibility for what passes through your proxy, and be aware that some features such as Predictions could be considered as Gambling in some countries which may be illegal for minors.
-If your county doesn't have that feature, it's for a reason. Be aware and search online.
+                  WARNING: Enabling this option while proxying thru another country could enable features that are not enabled on your country (such as Predictions, Prime Subscriptions, Currency Changes and others). 
                 </b>
+                </small>
+                <br />
+                <small>
+                <b>
+                  You accept full responsibility for what passes through your proxy or public ones, and be aware that some features such as Predictions could be considered as Gambling in some countries which may be illegal for minors.
+                </b>
+                </small>
+                <br />
+                <small>
+                <b>
+                    If your county doesn't have that feature, it's for a reason. Be aware and search online.
+                </b>
+                </small>
               </small>
             </li>
+            <br />
             <small><b>Expiration date:</b> 2038-01-19T03:14:07.000Z</small>
           </ul>
         </div>

--- a/src/options/page.html
+++ b/src/options/page.html
@@ -70,24 +70,30 @@
                   TTV LOL PRO's passport!
                 </b>
                 <br />
-                </small>
-                <small>
+              </small>
+              <small>
                 <b>
-                  WARNING: Enabling this option while proxying thru another country could enable features that are not enabled on your country (such as Predictions, Prime Subscriptions, Currency Changes and others). 
+                  WARNING: Enabling this option while proxying through another
+                  country could enable features that are not enabled on your
+                  country (such as Predictions, Prime Subscriptions, Currency
+                  Changes and others).
                 </b>
-                </small>
-                <br />
-                <small>
+              </small>
+              <br />
+              <small>
                 <b>
-                  You accept full responsibility for what passes through your proxy or public ones, and be aware that some features such as Predictions could be considered as Gambling in some countries which may be illegal for minors.
+                  You accept full responsibility for what passes through your
+                  proxy or public ones, and be aware that some features such as
+                  Predictions could be considered as Gambling in some countries
+                  which may be illegal for minors.
                 </b>
-                </small>
-                <br />
-                <small>
+              </small>
+              <br />
+              <small>
                 <b>
-                    If your county doesn't have that feature, it's for a reason. Be aware and search online.
+                  If your country doesn't have that feature, it's for a reason.
+                  Be aware and search online.
                 </b>
-                </small>
               </small>
             </li>
             <br />

--- a/src/options/page.html
+++ b/src/options/page.html
@@ -69,6 +69,10 @@
                   Only enable this option if you are experiencing issues with
                   TTV LOL PRO's passport!
                 </b>
+                <b>
+                  WARNING: Enabling this option while proxying thru another country could enable features that are not enabled on your country (such as Predictions, Prime Subscriptions, Currency Changes and others). You accept full responsibility for what passes through your proxy, and be aware that some features such as Predictions could be considered as Gambling in some countries which may be illegal for minors.
+If your county doesn't have that feature, it's for a reason. Be aware and search online.
+                </b>
               </small>
             </li>
             <small><b>Expiration date:</b> 2038-01-19T03:14:07.000Z</small>

--- a/src/options/page.html
+++ b/src/options/page.html
@@ -69,8 +69,8 @@
                   Only enable this option if you are experiencing issues with
                   TTV LOL PRO's passport!
                 </b>
-                <br />
               </small>
+              <br />
               <small>
                 <b>
                   WARNING: Enabling this option while proxying through another


### PR DESCRIPTION
This PR aims to improve and explain in a better way what could happen if "Make the passport a laissez-passer" is enabling either using your own proxy or the ones provided publicly. 