### PR TITLE
Allow EU/NA restricted proxies and block api.ttv.lol (V1 proxy)

### DIFF
--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -188,6 +188,8 @@ function isOptimizedProxyUrlAllowed(url: string): AllowedResult {
     "lb-eu2.cdn-perfprod.com",
     "lb-na.cdn-perfprod.com",
     "lb-as.cdn-perfprod.com",
+    // *.ttv.lol
+    "api.ttv.lol",
   ];
   if (proxiesV1.some(proxy => urlLower.includes(proxy))) {
     return [false, "TTV LOL PRO v1 proxies are not compatible"];
@@ -223,6 +225,14 @@ function isNormalProxyUrlAllowed(url: string): AllowedResult {
 
   // Allow donator proxy (password protected).
   const proxyInfo = getProxyInfoFromUrl(urlLower);
+  if (proxyInfo.host === "eu.restricted.api.cdn-perfprod.com") {
+    return [true];
+  }
+  // Allow donator proxy (password protected).
+  if (proxyInfo.host === "na.restricted.api.cdn-perfprod.com") {
+    return [true];
+  }
+  // Allow donator proxy (password protected).
   if (proxyInfo.host === "restricted.api.cdn-perfprod.com") {
     return [true];
   }

--- a/src/options/page.html
+++ b/src/options/page.html
@@ -96,7 +96,6 @@
                 </b>
               </small>
             </li>
-            <br />
             <small><b>Expiration date:</b> 2038-01-19T03:14:07.000Z</small>
           </ul>
         </div>

--- a/src/store/getDefaultState.ts
+++ b/src/store/getDefaultState.ts
@@ -7,7 +7,7 @@ export default function getDefaultState() {
     adLogEnabled: true,
     adLogLastSent: 0,
     dnsResponses: [],
-    normalProxies: isChromium ? ["chrome.api.cdn-perfprod.com:4023"] : [],
+    normalProxies: ["chrome.api.cdn-perfprod.com:4023"],
     openedTwitchTabs: [],
     optimizedProxies: isChromium ? [] : ["firefox.api.cdn-perfprod.com:2023"],
     optimizedProxiesEnabled: !isChromium,


### PR DESCRIPTION
This PR aims to add the new EU/NA restricted proxy (`na.restricted.api.cdn-perfprod.com` and `eu.restricted.api.cdn-perfprod.com` to the list of allowed proxies, including `restricted.api.cdn-perfprod.com`

This PR also adds `api.ttv.lol` as a blocked V1 proxy (as V1 proxies are not compatible with V2)

Also, I consider that we should allow Firefox users who have issues with optimized proxies to use the Chrome proxy for proxy all requests, so `chrome.api.cdn-perfprod.com:4023` is inserted by default on Chrome & Firefox (removed check isChromium) 

And lastly, removed an extra space I mistakenly inserted in my last PR