### PR TITLE
✨ Add beta private proxies

### DIFF
--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -227,6 +227,8 @@ function isNormalProxyUrlAllowed(url: string): AllowedResult {
   const restrictedProxyHosts = [
     "eu.restricted.api.cdn-perfprod.com",
     "na.restricted.api.cdn-perfprod.com",
+    "beta.eu.restricted.api.cdn-perfprod.com",
+    "beta.na.restricted.api.cdn-perfprod.com",
     "restricted.api.cdn-perfprod.com",
   ];
   const proxyInfo = getProxyInfoFromUrl(urlLower);


### PR DESCRIPTION
Allow the new upcoming beta private proxies with some neat features: `beta.na.restricted.api.cdn-perfprod.com` and `beta.eu.restricted.api.cdn-perfprod.com`