### PR TITLE
Whitelisting via tab analysis for chromium

### DIFF
--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -10,6 +10,7 @@ import onStartupStoreCleanup from "./handlers/onStartupStoreCleanup";
 import onTabCreated from "./handlers/onTabCreated";
 import onTabRemoved from "./handlers/onTabRemoved";
 import onTabUpdated from "./handlers/onTabUpdated";
+import onProxySettingsChange from "./handlers/onProxySettingsChanged";
 
 console.info("🚀 Background script loaded.");
 
@@ -36,6 +37,9 @@ if (isChromium) {
   browser.tabs.onCreated.addListener(onTabCreated);
   browser.tabs.onUpdated.addListener(onTabUpdated);
   browser.tabs.onRemoved.addListener(onTabRemoved);
+
+  // Listen to whether proxy is set or not
+  chrome.proxy.settings.onChange.addListener(onProxySettingsChange);
 } else {
   // Block tracking pixels.
   browser.webRequest.onBeforeRequest.addListener(

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -5,12 +5,12 @@ import onAuthRequired from "./handlers/onAuthRequired";
 import onBeforeSendHeaders from "./handlers/onBeforeSendHeaders";
 import onBeforeVideoWeaverRequest from "./handlers/onBeforeVideoWeaverRequest";
 import onProxyRequest from "./handlers/onProxyRequest";
+import onProxySettingsChange from "./handlers/onProxySettingsChanged";
 import onResponseStarted from "./handlers/onResponseStarted";
 import onStartupStoreCleanup from "./handlers/onStartupStoreCleanup";
 import onTabCreated from "./handlers/onTabCreated";
 import onTabRemoved from "./handlers/onTabRemoved";
 import onTabUpdated from "./handlers/onTabUpdated";
-import onProxySettingsChange from "./handlers/onProxySettingsChanged";
 
 console.info("🚀 Background script loaded.");
 

--- a/src/background/handlers/onProxySettingsChanged.ts
+++ b/src/background/handlers/onProxySettingsChanged.ts
@@ -1,6 +1,9 @@
 import store from "../../store";
 
-export default function onProxySettingsChange(details: chrome.types.ChromeSettingGetResultDetails) {
-    console.log("PROXY SETTINGS CHANGE: " + details.levelOfControl);
-    store.state.chromiumProxyActive = details.levelOfControl == "controlled_by_this_extension";
+export default function onProxySettingsChange(
+  details: chrome.types.ChromeSettingGetResultDetails
+) {
+  console.log("PROXY SETTINGS CHANGE: " + details.levelOfControl);
+  store.state.chromiumProxyActive =
+    details.levelOfControl == "controlled_by_this_extension";
 }

--- a/src/background/handlers/onProxySettingsChanged.ts
+++ b/src/background/handlers/onProxySettingsChanged.ts
@@ -1,0 +1,6 @@
+import store from "../../store";
+
+export default function onProxySettingsChange(details: chrome.types.ChromeSettingGetResultDetails) {
+    console.log("PROXY SETTINGS CHANGE: " + details.levelOfControl);
+    store.state.chromiumProxyActive = details.levelOfControl == "controlled_by_this_extension";
+}

--- a/src/background/handlers/onStartupStoreCleanup.ts
+++ b/src/background/handlers/onStartupStoreCleanup.ts
@@ -16,4 +16,5 @@ export default function onStartupStoreCleanup(): void {
   store.state.openedTwitchTabs = [];
   store.state.streamStatuses = {};
   store.state.videoWeaverUrlsByChannel = {};
+  store.state.chromiumProxyActive = false;
 }

--- a/src/background/handlers/onTabCreated.ts
+++ b/src/background/handlers/onTabCreated.ts
@@ -3,6 +3,7 @@ import getHostFromUrl from "../../common/ts/getHostFromUrl";
 import isChromium from "../../common/ts/isChromium";
 import { updateProxySettings } from "../../common/ts/proxySettings";
 import { twitchTvHostRegex } from "../../common/ts/regexes";
+import isChannelWhitelisted from "../../common/ts/isChannelWhitelisted";
 import store from "../../store";
 
 export default function onTabCreated(tab: Tabs.Tab): void {
@@ -10,8 +11,13 @@ export default function onTabCreated(tab: Tabs.Tab): void {
   const host = getHostFromUrl(tab.url);
   if (host != null && twitchTvHostRegex.test(host)) {
     console.log(`➕ Opened Twitch tab: ${tab.id}`);
-    if (isChromium && store.state.openedTwitchTabs.length === 0) {
-      updateProxySettings();
+    if (isChromium) {
+      var isNonWhitelistedChannel = true;
+      const url = new URL(tab.url);
+      if (url.pathname && url.pathname.length > 0) {
+        isNonWhitelistedChannel = !isChannelWhitelisted(url.pathname.substring(1));
+      }
+      if (isNonWhitelistedChannel && !store.state.chromiumProxyActive) updateProxySettings();
     }
     store.state.openedTwitchTabs.push(tab.id);
   }

--- a/src/background/handlers/onTabCreated.ts
+++ b/src/background/handlers/onTabCreated.ts
@@ -1,9 +1,9 @@
 import { Tabs } from "webextension-polyfill";
 import getHostFromUrl from "../../common/ts/getHostFromUrl";
+import isChannelWhitelisted from "../../common/ts/isChannelWhitelisted";
 import isChromium from "../../common/ts/isChromium";
 import { updateProxySettings } from "../../common/ts/proxySettings";
 import { twitchTvHostRegex } from "../../common/ts/regexes";
-import isChannelWhitelisted from "../../common/ts/isChannelWhitelisted";
 import store from "../../store";
 
 export default function onTabCreated(tab: Tabs.Tab): void {
@@ -15,9 +15,12 @@ export default function onTabCreated(tab: Tabs.Tab): void {
       var isNonWhitelistedChannel = true;
       const url = new URL(tab.url);
       if (url.pathname && url.pathname.length > 0) {
-        isNonWhitelistedChannel = !isChannelWhitelisted(url.pathname.substring(1));
+        isNonWhitelistedChannel = !isChannelWhitelisted(
+          url.pathname.substring(1)
+        );
       }
-      if (isNonWhitelistedChannel && !store.state.chromiumProxyActive) updateProxySettings();
+      if (isNonWhitelistedChannel && !store.state.chromiumProxyActive)
+        updateProxySettings();
     }
     store.state.openedTwitchTabs.push(tab.id);
   }

--- a/src/background/handlers/onTabRemoved.ts
+++ b/src/background/handlers/onTabRemoved.ts
@@ -1,5 +1,7 @@
+import browser from "webextension-polyfill";
 import isChromium from "../../common/ts/isChromium";
 import { clearProxySettings } from "../../common/ts/proxySettings";
+import isChannelWhitelisted from "../../common/ts/isChannelWhitelisted";
 import store from "../../store";
 
 export default function onTabRemoved(tabId: number): void {
@@ -7,8 +9,24 @@ export default function onTabRemoved(tabId: number): void {
   if (index !== -1) {
     console.log(`➖ Closed Twitch tab: ${tabId}`);
     store.state.openedTwitchTabs.splice(index, 1);
-    if (isChromium && store.state.openedTwitchTabs.length === 0) {
-      clearProxySettings();
+    if (isChromium) {
+      if (store.state.openedTwitchTabs.length === 0) {
+        clearProxySettings();
+        return;
+      }
+
+      Promise.all(store.state.openedTwitchTabs.map(tabId => {
+        return browser.tabs.get(tabId).then(tab => {
+          if (!tab.url) return false;
+          const url = new URL(tab.url);
+          if (!url.pathname || url.pathname == '/') return false;
+          return isChannelWhitelisted(url.pathname.substring(1));
+        }).catch(() => false);
+      })).then(res => {
+        if (!res.includes(false) && store.state.chromiumProxyActive) {
+          clearProxySettings();
+        }
+      });
     }
   }
 }

--- a/src/background/handlers/onTabRemoved.ts
+++ b/src/background/handlers/onTabRemoved.ts
@@ -1,7 +1,7 @@
 import browser from "webextension-polyfill";
+import isChannelWhitelisted from "../../common/ts/isChannelWhitelisted";
 import isChromium from "../../common/ts/isChromium";
 import { clearProxySettings } from "../../common/ts/proxySettings";
-import isChannelWhitelisted from "../../common/ts/isChannelWhitelisted";
 import store from "../../store";
 
 export default function onTabRemoved(tabId: number): void {
@@ -15,14 +15,19 @@ export default function onTabRemoved(tabId: number): void {
         return;
       }
 
-      Promise.all(store.state.openedTwitchTabs.map(tabId => {
-        return browser.tabs.get(tabId).then(tab => {
-          if (!tab.url) return false;
-          const url = new URL(tab.url);
-          if (!url.pathname || url.pathname == '/') return false;
-          return isChannelWhitelisted(url.pathname.substring(1));
-        }).catch(() => false);
-      })).then(res => {
+      Promise.all(
+        store.state.openedTwitchTabs.map(tabId => {
+          return browser.tabs
+            .get(tabId)
+            .then(tab => {
+              if (!tab.url) return false;
+              const url = new URL(tab.url);
+              if (!url.pathname || url.pathname == "/") return false;
+              return isChannelWhitelisted(url.pathname.substring(1));
+            })
+            .catch(() => false);
+        })
+      ).then(res => {
         if (!res.includes(false) && store.state.chromiumProxyActive) {
           clearProxySettings();
         }

--- a/src/background/handlers/onTabUpdated.ts
+++ b/src/background/handlers/onTabUpdated.ts
@@ -1,13 +1,12 @@
-import browser from "webextension-polyfill";
-import { Tabs } from "webextension-polyfill";
+import browser, { Tabs } from "webextension-polyfill";
 import getHostFromUrl from "../../common/ts/getHostFromUrl";
+import isChannelWhitelisted from "../../common/ts/isChannelWhitelisted";
 import isChromium from "../../common/ts/isChromium";
 import {
   clearProxySettings,
   updateProxySettings,
 } from "../../common/ts/proxySettings";
 import { twitchTvHostRegex } from "../../common/ts/regexes";
-import isChannelWhitelisted from "../../common/ts/isChannelWhitelisted";
 import store from "../../store";
 
 export default function onTabUpdated(
@@ -31,7 +30,9 @@ export default function onTabUpdated(
       var isNonWhitelistedPage = true;
       const urlObj = new URL(url);
       if (urlObj.pathname && urlObj.pathname.length > 0) {
-        isNonWhitelistedPage = !isChannelWhitelisted(urlObj.pathname.substring(1));
+        isNonWhitelistedPage = !isChannelWhitelisted(
+          urlObj.pathname.substring(1)
+        );
       }
       if (isNonWhitelistedPage) updateProxySettings();
     }
@@ -47,15 +48,20 @@ export default function onTabUpdated(
           clearProxySettings();
           return;
         }
-  
-        Promise.all(store.state.openedTwitchTabs.map(tabId => {
-          return browser.tabs.get(tabId).then(tab => {
-            if (!tab.url) return false;
-            const url = new URL(tab.url);
-            if (!url.pathname || url.pathname == '/') return false;
-            return isChannelWhitelisted(url.pathname.substring(1));
-          }).catch(() => false);
-        })).then(res => {
+
+        Promise.all(
+          store.state.openedTwitchTabs.map(tabId => {
+            return browser.tabs
+              .get(tabId)
+              .then(tab => {
+                if (!tab.url) return false;
+                const url = new URL(tab.url);
+                if (!url.pathname || url.pathname == "/") return false;
+                return isChannelWhitelisted(url.pathname.substring(1));
+              })
+              .catch(() => false);
+          })
+        ).then(res => {
           if (!res.includes(false) && store.state.chromiumProxyActive) {
             clearProxySettings();
           }
@@ -66,14 +72,19 @@ export default function onTabUpdated(
   if (isTwitchTab && wasTwitchTab) {
     console.log(`Changed Twitch tab: ${tabId}`);
     if (isChromium) {
-      Promise.all(store.state.openedTwitchTabs.map(tabId => {
-        return browser.tabs.get(tabId).then(tab => {
-          if (!tab.url) return false;
-          const url = new URL(tab.url);
-          if (!url.pathname || url.pathname == '/') return false;
-          return isChannelWhitelisted(url.pathname.substring(1));
-        }).catch(() => false);
-      })).then(res => {
+      Promise.all(
+        store.state.openedTwitchTabs.map(tabId => {
+          return browser.tabs
+            .get(tabId)
+            .then(tab => {
+              if (!tab.url) return false;
+              const url = new URL(tab.url);
+              if (!url.pathname || url.pathname == "/") return false;
+              return isChannelWhitelisted(url.pathname.substring(1));
+            })
+            .catch(() => false);
+        })
+      ).then(res => {
         if (!res.includes(false) && store.state.chromiumProxyActive) {
           clearProxySettings();
         } else if (res.includes(false) && !store.state.chromiumProxyActive) {

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -103,11 +103,11 @@ function main() {
     }
   });
   // Whitelisted channels
-    listInit(whitelistedChannelsListElement, "whitelistedChannels", {
-      getAlreadyExistsAlertMessage: channelName =>
-        `'${channelName}' is already whitelisted`,
-      getPromptPlaceholder: () => "Enter a channel name…",
-    });
+  listInit(whitelistedChannelsListElement, "whitelistedChannels", {
+    getAlreadyExistsAlertMessage: channelName =>
+      `'${channelName}' is already whitelisted`,
+    getPromptPlaceholder: () => "Enter a channel name…",
+  });
   // Proxies
   if (isChromium) {
     optimizedProxiesDivElement.style.display = "none";

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -103,15 +103,11 @@ function main() {
     }
   });
   // Whitelisted channels
-  if (isChromium) {
-    whitelistedChannelsSectionElement.style.display = "none";
-  } else {
     listInit(whitelistedChannelsListElement, "whitelistedChannels", {
       getAlreadyExistsAlertMessage: channelName =>
         `'${channelName}' is already whitelisted`,
       getPromptPlaceholder: () => "Enter a channel name…",
     });
-  }
   // Proxies
   if (isChromium) {
     optimizedProxiesDivElement.style.display = "none";

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -67,9 +67,6 @@ function setStreamStatusElement(channelName: string) {
     setProxyStatus(channelNameLower, status);
     setWhitelistStatus(channelNameLower);
     streamStatusElement.style.display = "flex";
-    if (isChromium) {
-      whitelistStatusElement.style.display = "none";
-    }
   } else {
     streamStatusElement.style.display = "none";
   }

--- a/src/store/getDefaultState.ts
+++ b/src/store/getDefaultState.ts
@@ -6,6 +6,7 @@ export default function getDefaultState() {
     adLog: [],
     adLogEnabled: true,
     adLogLastSent: 0,
+    chromiumProxyActive: false,
     dnsResponses: [],
     normalProxies: ["chrome.api.cdn-perfprod.com:4023"],
     openedTwitchTabs: [],

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -8,6 +8,7 @@ export interface State {
   adLog: AdLogEntry[];
   adLogEnabled: boolean;
   adLogLastSent: number;
+  chromiumProxyActive: boolean;
   dnsResponses: DnsResponse[];
   normalProxies: string[];
   openedTwitchTabs: number[];


### PR DESCRIPTION
After noticing that whitelisting only worked on Firefox, I really wanted the same feature for Chrome.

Ran into the insurmountable issue of being limited by Chrome's proxy security and the proxy auto-config script.

So I decided to come up with a compromised solution that involves basing whether to enable proxying based on the twitch tabs you have open. If you only have whitelisted tabs open then the proxy will not be enabled but if even one tab is open that isn't whitelisted then the proxy will be enabled.

Feels free to close this PR if this isn't a suitable solution for you guys :)