### PR TITLE
Feature/proxy protocol support

### DIFF
--- a/src/background/handlers/onBeforeVideoWeaverRequest.ts
+++ b/src/background/handlers/onBeforeVideoWeaverRequest.ts
@@ -38,7 +38,7 @@ export default function onBeforeVideoWeaverRequest(
       textLower.includes("https://example.com") &&
       textLower.includes("https://help.twitch.tv/");
     const proxy =
-      details.proxyInfo && details.proxyInfo.type !== "direct"
+      details.proxyInfo && details.proxyInfo.type !== "DIRECT"
         ? getUrlFromProxyInfo(details.proxyInfo)
         : null;
 

--- a/src/background/handlers/onProxyRequest.ts
+++ b/src/background/handlers/onProxyRequest.ts
@@ -32,7 +32,7 @@ export default async function onProxyRequest(
   }
 
   const host = getHostFromUrl(details.url);
-  if (!host) return { type: "direct" };
+  if (!host) return { type: "DIRECT" };
 
   const documentHost = details.documentUrl
     ? getHostFromUrl(details.documentUrl)
@@ -43,7 +43,7 @@ export default async function onProxyRequest(
     !passportHostRegex.test(documentHost) && // Passport requests have a `passport.twitch.tv` document URL.
     !twitchTvHostRegex.test(documentHost)
   ) {
-    return { type: "direct" };
+    return { type: "DIRECT" };
   }
 
   const proxies = store.state.optimizedProxiesEnabled
@@ -92,12 +92,12 @@ export default async function onProxyRequest(
   if (proxyUsherRequest && usherHostRegex.test(host)) {
     if (details.url.includes("/vod/")) {
       console.log(`✋ '${details.url}' is a VOD manifest.`);
-      return { type: "direct" };
+      return { type: "DIRECT" };
     }
     const channelName = findChannelFromUsherUrl(details.url);
     if (isChannelWhitelisted(channelName)) {
       console.log(`✋ Channel '${channelName}' is whitelisted.`);
-      return { type: "direct" };
+      return { type: "DIRECT" };
     }
     console.log(
       `⌛ Proxying ${details.url} (${
@@ -119,7 +119,7 @@ export default async function onProxyRequest(
       findChannelFromTwitchTvUrl(tabUrl);
     if (isChannelWhitelisted(channelName)) {
       console.log(`✋ Channel '${channelName}' is whitelisted.`);
-      return { type: "direct" };
+      return { type: "DIRECT" };
     }
     console.log(
       `⌛ Proxying ${details.url} (${
@@ -149,12 +149,12 @@ export default async function onProxyRequest(
     return proxyInfoArray;
   }
 
-  return { type: "direct" };
+  return { type: "DIRECT" };
 }
 
 function getProxyInfoArrayFromUrls(urls: string[]): ProxyInfo[] {
   return [
     ...urls.map(getProxyInfoFromUrl),
-    { type: "direct" } as ProxyInfo, // Fallback to direct connection if all proxies fail.
+    { type: "DIRECT" } as ProxyInfo, // Fallback to direct connection if all proxies fail.
   ];
 }

--- a/src/background/handlers/onResponseStarted.ts
+++ b/src/background/handlers/onResponseStarted.ts
@@ -171,7 +171,7 @@ function getProxyFromDetails(
     return getUrlFromProxyInfo(possibleProxies[0]);
   } else {
     const proxyInfo = details.proxyInfo; // Firefox only.
-    if (!proxyInfo || proxyInfo.type === "direct") return null;
+    if (!proxyInfo || proxyInfo.type === "DIRECT") return null;
     return getUrlFromProxyInfo(proxyInfo);
   }
 }

--- a/src/common/ts/proxyInfo.ts
+++ b/src/common/ts/proxyInfo.ts
@@ -1,18 +1,34 @@
 import { Address6 } from "ip-address";
-import type { ProxyInfo } from "../../types";
+import type { ProxyInfo, ProxyScheme } from "../../types";
 
-export function getProxyInfoFromUrl(
-  url: string
-): ProxyInfo & { type: "http"; host: string; port: number } {
+export const proxySchemes: { [key: string]: ProxyScheme } = {
+  direct: "DIRECT",
+  http: "PROXY",
+  https: "HTTPS",
+  socks: "SOCKS",
+  socks4: "SOCKS4",
+  socks5: "SOCKS5",
+  quic: "QUIC",
+};
+
+export function getProxyInfoFromUrl(url: string) {
+  let protocol = "";
+  if (url.includes("://")) {
+    let [proto, urlWithoutProtocol] = url.split("://");
+    protocol = proto;
+    url = urlWithoutProtocol;
+  }
   const lastIndexOfAt = url.lastIndexOf("@");
-  const hostname = url.substring(lastIndexOfAt + 1, url.length);
+  let hostname = url.substring(lastIndexOfAt + 1, url.length);
   const lastIndexOfColon = getLastIndexOfColon(hostname);
-
+  hostname;
   let host: string | undefined = undefined;
   let port: number | undefined = undefined;
   if (lastIndexOfColon === -1) {
     host = hostname;
-    port = 3128; // Default port
+    if (!protocol) {
+      port = 3128; // Default port
+    }
   } else {
     host = hostname.substring(0, lastIndexOfColon);
     port = Number(hostname.substring(lastIndexOfColon + 1, hostname.length));
@@ -31,7 +47,8 @@ export function getProxyInfoFromUrl(
   }
 
   return {
-    type: "http",
+    type: proxySchemes[protocol] ?? "PROXY",
+    protocol,
     host,
     port,
     username,

--- a/src/common/ts/proxyInfo.ts
+++ b/src/common/ts/proxyInfo.ts
@@ -27,12 +27,12 @@ const defaultPorts: Partial<{
 export function getProxyInfoFromUrl(url: string) {
   let protocol = "";
   if (url.includes("://")) {
-    let [_protocol, urlWithoutProtocol] = url.split("://");
+    const [_protocol, urlWithoutProtocol] = url.split("://");
     protocol = _protocol;
     url = urlWithoutProtocol;
   }
   const lastIndexOfAt = url.lastIndexOf("@");
-  let hostname = url.substring(lastIndexOfAt + 1, url.length);
+  const hostname = url.substring(lastIndexOfAt + 1, url.length);
   const lastIndexOfColon = getLastIndexOfColon(hostname);
 
   let host: string | undefined = undefined;

--- a/src/common/ts/proxySettings.ts
+++ b/src/common/ts/proxySettings.ts
@@ -92,7 +92,7 @@ function getProxyInfoStringFromUrls(urls: string[]): string {
   return [
     ...urls.map(url => {
       const proxyInfo = getProxyInfoFromUrl(url);
-      return `PROXY ${getUrlFromProxyInfo({
+      return `${proxyInfo.type} ${getUrlFromProxyInfo({
         ...proxyInfo,
         // Don't include username/password in PAC script.
         username: undefined,

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -16,9 +16,10 @@ import sendAdLog from "../common/ts/sendAdLog";
 import store from "../store";
 import getDefaultState from "../store/getDefaultState";
 import type { State } from "../store/types";
-import { AllowedResult, KeyOfType, ProxyRequestType } from "../types";
+import { KeyOfType, ProxyRequestType } from "../types";
 
 //#region Types
+type AllowedResult = [boolean, string?];
 type InsertMode = "append" | "prepend" | "both";
 type StoreStringArrayKey = KeyOfType<typeof store.state, string[]>;
 type ListOptions = {

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -16,10 +16,9 @@ import sendAdLog from "../common/ts/sendAdLog";
 import store from "../store";
 import getDefaultState from "../store/getDefaultState";
 import type { State } from "../store/types";
-import { KeyOfType, ProxyRequestType } from "../types";
+import { AllowedResult, KeyOfType, ProxyRequestType } from "../types";
 
 //#region Types
-type AllowedResult = [boolean, string?];
 type InsertMode = "append" | "prepend" | "both";
 type StoreStringArrayKey = KeyOfType<typeof store.state, string[]>;
 type ListOptions = {
@@ -323,12 +322,16 @@ function isOptimizedProxyUrlAllowed(url: string): AllowedResult {
     return [false, "TTV LOL PRO v1 proxies are not compatible"];
   }
 
-  if (/^https?:\/\//i.test(url)) {
-    return [false, "Proxy URLs must not contain a protocol (e.g. 'http://')"];
+  const proxyInfo = getProxyInfoFromUrl(url);
+  if (proxyInfo.host.includes("/")) {
+    return [false, "Proxy URLs must not contain a path (e.g. '/path')"];
   }
 
-  if (url.includes("/")) {
-    return [false, "Proxy URLs must not contain a path (e.g. '/path')"];
+  try {
+    const host = url.substring(url.lastIndexOf("@") + 1, url.length);
+    new URL(`http://${host}`); // Throws if the host is invalid.
+  } catch {
+    return [false, `'${url}' is not a valid proxy URL`];
   }
 
   try {

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,9 +3,21 @@ export type KeyOfType<T, V> = keyof {
   [P in keyof T as T[P] extends V ? P : never]: any;
 };
 
+export type AllowedResult = [boolean, string?];
+
+// From https://chromium.googlesource.com/chromium/src/+/HEAD/net/docs/proxy.md#proxy-server-schemes
+export type ProxyScheme =
+  | "DIRECT"
+  | "PROXY"
+  | "HTTPS"
+  | "SOCKS"
+  | "SOCKS4"
+  | "SOCKS5"
+  | "QUIC";
+
 // From https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/proxy/ProxyInfo
 export interface ProxyInfo {
-  type: "direct" | "http" | "https" | "socks" | "socks4";
+  type: ProxyScheme;
   host?: string;
   port?: number;
   username?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,8 +3,6 @@ export type KeyOfType<T, V> = keyof {
   [P in keyof T as T[P] extends V ? P : never]: any;
 };
 
-export type AllowedResult = [boolean, string?];
-
 // From https://chromium.googlesource.com/chromium/src/+/HEAD/net/docs/proxy.md#proxy-server-schemes
 export type ProxyScheme =
   | "DIRECT"


### PR DESCRIPTION
Not coded for a while due to health conditions. Trying to get back into it slowly so go easy on me.

This adds support for additional proxy protocols that are [supported in chrome](https://chromium.googlesource.com/chromium/src/+/HEAD/net/docs/proxy.md#proxy-server-schemes). I personally like to use an encrypted proxy over TLS so I use `https`. That way your credentials aren't sent in plain-ish text (base64).

Supported proxies are (http was already supported):
- `http`
- `https`
- `socks4`
- `socks5`
- `quic`

This should be backwards compatible with the current implementation (defaulting to http) and will conform to the rules you have in to prevent your public proxies from being hammered.

Only tested with [Brave](https://brave.com/) (chromium).

Thanks for maintaining this project.