### PR TITLE
feat: support player.twitch.tv

### DIFF
--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -62,7 +62,7 @@ if (isChromium) {
   browser.webRequest.onBeforeSendHeaders.addListener(
     onBeforeTwitchTvSendHeaders,
     {
-      urls: ["https://www.twitch.tv/*", "https://m.twitch.tv/*"],
+      urls: ["https://www.twitch.tv/*", "https://m.twitch.tv/*", "https://player.twitch.tv/*"],
       types: ["main_frame"],
     },
     ["blocking", "requestHeaders"]

--- a/src/background/handlers/checkForOpenedTwitchTabs.ts
+++ b/src/background/handlers/checkForOpenedTwitchTabs.ts
@@ -12,7 +12,7 @@ export default function checkForOpenedTwitchTabs() {
     return store.addEventListener("load", checkForOpenedTwitchTabs);
 
   browser.tabs
-    .query({ url: ["https://www.twitch.tv/*", "https://m.twitch.tv/*"] })
+    .query({ url: ["https://www.twitch.tv/*", "https://m.twitch.tv/*", "https://player.twitch.tv/*"] })
     .then(tabs => {
       console.log(`🔍 Found ${tabs.length} opened Twitch tabs.`);
       store.state.openedTwitchTabs = tabs;

--- a/src/common/ts/findChannelFromTwitchTvUrl.ts
+++ b/src/common/ts/findChannelFromTwitchTvUrl.ts
@@ -10,6 +10,10 @@ export default function findChannelFromTwitchTvUrl(
   twitchTvUrl: string | undefined
 ): string | null {
   if (!twitchTvUrl) return null;
+  const url = new URL(twitchTvUrl)
+  if (url.host === "player.twitch.tv") {
+    return url.searchParams.get("channel")
+  }
   const match = twitchChannelNameRegex.exec(twitchTvUrl);
   if (!match) return null;
   const [, channelName] = match;

--- a/src/common/ts/regexes.ts
+++ b/src/common/ts/regexes.ts
@@ -3,7 +3,7 @@ export const twitchApiChannelNameRegex = /\/hls\/(.+)\.m3u8/i;
 export const twitchChannelNameRegex =
   /^https?:\/\/(?:www|m)\.twitch\.tv\/(?:videos\/|popout\/|moderator\/)?((?!(?:directory|downloads|jobs|p|privacy|search|settings|store|turbo)\b)\w+)/i;
 export const twitchGqlHostRegex = /^gql\.twitch\.tv$/i;
-export const twitchTvHostRegex = /^(?:www|m)\.twitch\.tv$/i;
+export const twitchTvHostRegex = /^(?:www|m|player)\.twitch\.tv$/i;
 export const usherHostRegex = /^usher\.ttvnw\.net$/i;
 export const videoWeaverHostRegex =
   /^(?:[a-z0-9-]+\.playlist\.(?:live-video|ttvnw)\.net|video-weaver\.[a-z0-9-]+\.hls\.ttvnw\.net)$/i;

--- a/src/manifest.chromium.json
+++ b/src/manifest.chromium.json
@@ -26,7 +26,7 @@
   },
   "content_scripts": [
     {
-      "matches": ["https://www.twitch.tv/*", "https://m.twitch.tv/*"],
+      "matches": ["https://www.twitch.tv/*", "https://m.twitch.tv/*", "https://player.twitch.tv/*"],
       "js": ["content/content.ts"],
       "run_at": "document_start"
     }

--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -26,7 +26,7 @@
   },
   "content_scripts": [
     {
-      "matches": ["https://www.twitch.tv/*", "https://m.twitch.tv/*"],
+      "matches": ["https://www.twitch.tv/*", "https://m.twitch.tv/*", "https://player.twitch.tv/*"],
       "js": ["content/content.ts"],
       "run_at": "document_start"
     }

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -783,7 +783,7 @@ generateTwitchTabsReportButtonElement.addEventListener("click", async () => {
   report += `Browser: ${userAgentParser.getBrowserName()} ${userAgentParser.getBrowserVersion()} (${userAgentParser.getOSName()} ${userAgentParser.getOSVersion()})\n\n`;
 
   const openedTabs = await browser.tabs.query({
-    url: ["https://www.twitch.tv/*", "https://m.twitch.tv/*"],
+    url: ["https://www.twitch.tv/*", "https://m.twitch.tv/*", "https://player.twitch.tv/*"],
   });
   const detectedTabs = store.state.openedTwitchTabs;
 


### PR DESCRIPTION
As the title implies just adds support for player.twitch.tv urls. ex: `https://player.twitch.tv/?channel=forsen&parent=twitch.tv`

Previously when using these embeds directly, these requests weren't proxied.