### PR TITLE
Release version 2.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ttv-lol-pro",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ttv-lol-pro",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "license": "GPL-3.0",
       "dependencies": {
         "bowser": "^2.11.0",
@@ -277,22 +277,22 @@
       }
     },
     "node_modules/@parcel/bundler-default": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.15.4.tgz",
-      "integrity": "sha512-4vkaZuwGqL8L7NqEgjRznz9/QoeVKk0Z6z2nzfpdnSWA4xX3moUj+JeoqGUbyFGuPzfCma4SA4+txnQbKu0edQ==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.16.1.tgz",
+      "integrity": "sha512-ruy+Yt96Jre2+5PSE4qcH7ETarIuQ+OIY8hejOQ53inVgu9QlvBJf/L2PhNkumHN2zA6m5f0m/MhB+amaee5ew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.15.4",
-        "@parcel/graph": "3.5.4",
-        "@parcel/plugin": "2.15.4",
-        "@parcel/rust": "2.15.4",
-        "@parcel/utils": "2.15.4",
+        "@parcel/diagnostic": "2.16.1",
+        "@parcel/graph": "3.6.1",
+        "@parcel/plugin": "2.16.1",
+        "@parcel/rust": "2.16.1",
+        "@parcel/utils": "2.16.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.4"
+        "parcel": "^2.16.1"
       },
       "funding": {
         "type": "opencollective",
@@ -300,15 +300,15 @@
       }
     },
     "node_modules/@parcel/cache": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.15.4.tgz",
-      "integrity": "sha512-x/QgMuVvXQV6uNhIF+6kz6SzhVVkwf6WPSVG/xQvGMEiBabForDVYIhIEuN3RzUXCU352CGM6d8TtLLg61W1fw==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.16.1.tgz",
+      "integrity": "sha512-qDlHQQ7RDfSi5MBnuFGCfQYiQQomsA5aZLntO5MCRD62VnMf9qz/RrCqpGFGOooljMoUaeVl0Q8ARvorRJJi8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/fs": "2.15.4",
-        "@parcel/logger": "2.15.4",
-        "@parcel/utils": "2.15.4",
+        "@parcel/fs": "2.16.1",
+        "@parcel/logger": "2.16.1",
+        "@parcel/utils": "2.16.1",
         "lmdb": "2.8.5"
       },
       "engines": {
@@ -319,13 +319,13 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.15.4"
+        "@parcel/core": "^2.16.1"
       }
     },
     "node_modules/@parcel/codeframe": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.15.4.tgz",
-      "integrity": "sha512-ErAPEQaJIpB+ocNZ3rl8AEK6piA7JBInwZLNU0eHMthm01Ssb10JkpAadyn1w9IVfCey+kqQcEeWv47Yh6mL1Q==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.16.1.tgz",
+      "integrity": "sha512-KLy9Fvf37SX6/wek2SUPw8A/W0kChcNXPUNeCIYWUFI4USAZ5KvesXS5RHUnrJTaR0XzD0Qia+MFJPgp6kuazQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -340,17 +340,17 @@
       }
     },
     "node_modules/@parcel/compressor-raw": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.15.4.tgz",
-      "integrity": "sha512-gECePZxVXBwyo0DYbAq4V4SimVzHaJ3p8QOgFIfOqNmlEBbhLf3QSjArFPJNKiHZaJuclh4a+IShFBN+u6tXXw==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.16.1.tgz",
+      "integrity": "sha512-44sHWuEyGwUvs2bG1t/hsBP0lR06HO2btrXhkUGL+HX6D8cZrkZfSBFnUrGYZURYRybyx8qkhcogf5SU5rbwAQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.15.4"
+        "@parcel/plugin": "2.16.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.4"
+        "parcel": "^2.16.1"
       },
       "funding": {
         "type": "opencollective",
@@ -358,97 +358,98 @@
       }
     },
     "node_modules/@parcel/config-default": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.15.4.tgz",
-      "integrity": "sha512-chUE4NpcSXpMfTcSmgl4Q78zH+ZFe0qdgZLBtF4EH2QQakW7wAXAYRxS2/P3xFkUj0/51sExhbCFWgulrlGDPw==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.16.1.tgz",
+      "integrity": "sha512-jBgbHW73MrEdiKH6LISLw5TZ2oVvyLm3GaYzwNkcRTUtSh6aRVjxvCWePdxy41dcwnMC/ABLsamtN4wokAKKSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/bundler-default": "2.15.4",
-        "@parcel/compressor-raw": "2.15.4",
-        "@parcel/namer-default": "2.15.4",
-        "@parcel/optimizer-css": "2.15.4",
-        "@parcel/optimizer-html": "2.15.4",
-        "@parcel/optimizer-image": "2.15.4",
-        "@parcel/optimizer-svg": "2.15.4",
-        "@parcel/optimizer-swc": "2.15.4",
-        "@parcel/packager-css": "2.15.4",
-        "@parcel/packager-html": "2.15.4",
-        "@parcel/packager-js": "2.15.4",
-        "@parcel/packager-raw": "2.15.4",
-        "@parcel/packager-svg": "2.15.4",
-        "@parcel/packager-wasm": "2.15.4",
-        "@parcel/reporter-dev-server": "2.15.4",
-        "@parcel/resolver-default": "2.15.4",
-        "@parcel/runtime-browser-hmr": "2.15.4",
-        "@parcel/runtime-js": "2.15.4",
-        "@parcel/runtime-rsc": "2.15.4",
-        "@parcel/runtime-service-worker": "2.15.4",
-        "@parcel/transformer-babel": "2.15.4",
-        "@parcel/transformer-css": "2.15.4",
-        "@parcel/transformer-html": "2.15.4",
-        "@parcel/transformer-image": "2.15.4",
-        "@parcel/transformer-js": "2.15.4",
-        "@parcel/transformer-json": "2.15.4",
-        "@parcel/transformer-node": "2.15.4",
-        "@parcel/transformer-postcss": "2.15.4",
-        "@parcel/transformer-posthtml": "2.15.4",
-        "@parcel/transformer-raw": "2.15.4",
-        "@parcel/transformer-react-refresh-wrap": "2.15.4",
-        "@parcel/transformer-svg": "2.15.4"
+        "@parcel/bundler-default": "2.16.1",
+        "@parcel/compressor-raw": "2.16.1",
+        "@parcel/namer-default": "2.16.1",
+        "@parcel/optimizer-css": "2.16.1",
+        "@parcel/optimizer-html": "2.16.1",
+        "@parcel/optimizer-image": "2.16.1",
+        "@parcel/optimizer-svg": "2.16.1",
+        "@parcel/optimizer-swc": "2.16.1",
+        "@parcel/packager-css": "2.16.1",
+        "@parcel/packager-html": "2.16.1",
+        "@parcel/packager-js": "2.16.1",
+        "@parcel/packager-raw": "2.16.1",
+        "@parcel/packager-svg": "2.16.1",
+        "@parcel/packager-wasm": "2.16.1",
+        "@parcel/reporter-dev-server": "2.16.1",
+        "@parcel/resolver-default": "2.16.1",
+        "@parcel/runtime-browser-hmr": "2.16.1",
+        "@parcel/runtime-js": "2.16.1",
+        "@parcel/runtime-rsc": "2.16.1",
+        "@parcel/runtime-service-worker": "2.16.1",
+        "@parcel/transformer-babel": "2.16.1",
+        "@parcel/transformer-css": "2.16.1",
+        "@parcel/transformer-html": "2.16.1",
+        "@parcel/transformer-image": "2.16.1",
+        "@parcel/transformer-js": "2.16.1",
+        "@parcel/transformer-json": "2.16.1",
+        "@parcel/transformer-node": "2.16.1",
+        "@parcel/transformer-postcss": "2.16.1",
+        "@parcel/transformer-posthtml": "2.16.1",
+        "@parcel/transformer-raw": "2.16.1",
+        "@parcel/transformer-react-refresh-wrap": "2.16.1",
+        "@parcel/transformer-svg": "2.16.1"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.15.4"
+        "@parcel/core": "^2.16.1"
       }
     },
     "node_modules/@parcel/config-webextension": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/config-webextension/-/config-webextension-2.15.4.tgz",
-      "integrity": "sha512-rphRcz057ojLGWtR/+znMFouYk+H+BCGkcRuni8ycGnnGPJekRkc38SI8L3lOC+Aj4sTsQW+6jTXTksNIfM7kw==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/config-webextension/-/config-webextension-2.16.1.tgz",
+      "integrity": "sha512-Ssp0GDsvXV3oqNaXozEer9i8FC2pZ2JnbG6A8Mw8fSKPXtqAMFd6cfSXS+KtVzQnK054BBig25dmi+lVM1z3VA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/config-default": "2.15.4",
-        "@parcel/packager-webextension": "2.15.4",
-        "@parcel/runtime-webextension": "2.15.4",
-        "@parcel/transformer-raw": "2.15.4",
-        "@parcel/transformer-webextension": "2.15.4"
+        "@parcel/config-default": "2.16.1",
+        "@parcel/packager-webextension": "2.16.1",
+        "@parcel/runtime-webextension": "2.16.1",
+        "@parcel/transformer-raw": "2.16.1",
+        "@parcel/transformer-webextension": "2.16.1"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.15.4"
+        "@parcel/core": "^2.16.1"
       }
     },
     "node_modules/@parcel/core": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.15.4.tgz",
-      "integrity": "sha512-+TXxTm58lFwXXObFAEclwKX1p1AdixcD+M7T4NeFIQzQ4F20Vr+6oybCSqW1exNA3uHqVDDFLx7TT78seVjvkg==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.16.1.tgz",
+      "integrity": "sha512-tza8oKYaPopGBwroGJKv7BrTg1lxTycS7SANIizxMB9FxDsAkq4vPny5/KHpFBcW3UTCGBvvNAG1oaVzeWF5Pg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@mischnic/json-sourcemap": "^0.1.1",
-        "@parcel/cache": "2.15.4",
-        "@parcel/diagnostic": "2.15.4",
-        "@parcel/events": "2.15.4",
-        "@parcel/feature-flags": "2.15.4",
-        "@parcel/fs": "2.15.4",
-        "@parcel/graph": "3.5.4",
-        "@parcel/logger": "2.15.4",
-        "@parcel/package-manager": "2.15.4",
-        "@parcel/plugin": "2.15.4",
-        "@parcel/profiler": "2.15.4",
-        "@parcel/rust": "2.15.4",
+        "@parcel/cache": "2.16.1",
+        "@parcel/diagnostic": "2.16.1",
+        "@parcel/events": "2.16.1",
+        "@parcel/feature-flags": "2.16.1",
+        "@parcel/fs": "2.16.1",
+        "@parcel/graph": "3.6.1",
+        "@parcel/logger": "2.16.1",
+        "@parcel/package-manager": "2.16.1",
+        "@parcel/plugin": "2.16.1",
+        "@parcel/profiler": "2.16.1",
+        "@parcel/rust": "2.16.1",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/types": "2.15.4",
-        "@parcel/utils": "2.15.4",
-        "@parcel/workers": "2.15.4",
+        "@parcel/types": "2.16.1",
+        "@parcel/utils": "2.16.1",
+        "@parcel/workers": "2.16.1",
         "base-x": "^3.0.11",
         "browserslist": "^4.24.5",
         "clone": "^2.1.2",
@@ -468,9 +469,9 @@
       }
     },
     "node_modules/@parcel/diagnostic": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.15.4.tgz",
-      "integrity": "sha512-8MAqefwzBKceNN3364OLm+p4HRD7AfimfFW3MntLxPB6bnelc9UBg5c9zEm34zYEctbmky8gqYgAUSDjqYC5Hw==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.16.1.tgz",
+      "integrity": "sha512-PJl7/QGsPboAMVFZId31iGMMY70AllZNOtYka9rTZRjTiBhZw4VrAG/RdqqKzjVuL6fZhurmfcwWzj+3gx8ccg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -486,9 +487,9 @@
       }
     },
     "node_modules/@parcel/error-overlay": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/error-overlay/-/error-overlay-2.15.4.tgz",
-      "integrity": "sha512-xxeaWm8fV8Z4uGy/c09mOvmFSHBOgF1gCMQwLCwZvfMLqIWkdZaUQ2cRhWZIS6pOXaRVC7YpcXzk2DOiSUNSbQ==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/error-overlay/-/error-overlay-2.16.1.tgz",
+      "integrity": "sha512-9vZq5ijoAn+JjodXc5FNy6ZQ2qpqSAaKDs+wCi4JrZMJJx7+dXZ31xtbpmP2SzG2Wppf8KhS/dOGmtQh65jT8Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -500,9 +501,9 @@
       }
     },
     "node_modules/@parcel/events": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.15.4.tgz",
-      "integrity": "sha512-SBq4zstaFr7XQaXNaQmUuVh1swCUHrhtPCOSofvkJoQGhjsuhQlh4t0NmUikyKNdj7C1j40xCS1kGHuUO29b0g==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.1.tgz",
+      "integrity": "sha512-+U7Trb2W8fm8w/OjwQpWN/Tepiwim/YNXuyPrhikFnsrg6QDdDTD/8/km4ah8Bzr0u4hIrn1k32InwDMCF5sig==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -514,9 +515,9 @@
       }
     },
     "node_modules/@parcel/feature-flags": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/feature-flags/-/feature-flags-2.15.4.tgz",
-      "integrity": "sha512-DJqZVtbfjWJseM0gk7yyDkAuOhP7/FVwZ/YVqjozIqXBhmQm07xctiqNQyZX2vBbQsxmVbjpqyq+DOj45WPEzQ==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/feature-flags/-/feature-flags-2.16.1.tgz",
+      "integrity": "sha512-MY/z4gKZWk0MKvP+gpU42kiE9W4f9NM1fSCa1OcdqF7IUJDDM41CDJ9rbwSQrroDddIViaNzsLo7aSYVI/C7aA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -528,18 +529,18 @@
       }
     },
     "node_modules/@parcel/fs": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.15.4.tgz",
-      "integrity": "sha512-5cahD2ByQaSi+YN0aDvrMWXZvs3mP7C5ey8zcDTDn7JxJa51sMqOQcdU3VUTzQFtAPeRM2KxUkxLhBBXgQqHZA==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.16.1.tgz",
+      "integrity": "sha512-/akyrCaurd8rfgXuT6tDAK6I1JfW56TFJmzfIwuFSPbRy3YVu4JKN1g2PShpOLPdnqfWZNCcsd+yuuMFVhA2HA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/feature-flags": "2.15.4",
-        "@parcel/rust": "2.15.4",
-        "@parcel/types-internal": "2.15.4",
-        "@parcel/utils": "2.15.4",
+        "@parcel/feature-flags": "2.16.1",
+        "@parcel/rust": "2.16.1",
+        "@parcel/types-internal": "2.16.1",
+        "@parcel/utils": "2.16.1",
         "@parcel/watcher": "^2.0.7",
-        "@parcel/workers": "2.15.4"
+        "@parcel/workers": "2.16.1"
       },
       "engines": {
         "node": ">= 16.0.0"
@@ -549,17 +550,17 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.15.4"
+        "@parcel/core": "^2.16.1"
       }
     },
     "node_modules/@parcel/graph": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-3.5.4.tgz",
-      "integrity": "sha512-uF7kyQXWK2fQZvG5eE0N3avYGLQE5Q0vyJsyypNcFW3kXNnrkZCUtbG7urmdae9mmZ2jXIVN4q4Bhd9pefGj9A==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-3.6.1.tgz",
+      "integrity": "sha512-82sjbjrSPK5BXH0tb65tQl/qvo/b2vsyA5F6z3SaQ/c3A5bmv5RxTvse1AgOb0St0lZ7ALaZibj1qZFBUyjdqw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/feature-flags": "2.15.4",
+        "@parcel/feature-flags": "2.16.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -571,14 +572,14 @@
       }
     },
     "node_modules/@parcel/logger": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.15.4.tgz",
-      "integrity": "sha512-rQ7F5+FMQ7t+w5NGFRT8CWHhym0aunduufCjlafvRzUSKEN/5/nwTfCe9I5QsthGlXJWs+ZTy4zQ+wLtZQRBKQ==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.1.tgz",
+      "integrity": "sha512-w9Qpp5S79fqn6nh/VqVYG4kCbIeW45zdPvYJMFgE90zhBRLrOnqw06cRZQdKj24C7/kdqOFFbrJ3B5uTsYeS0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.15.4",
-        "@parcel/events": "2.15.4"
+        "@parcel/diagnostic": "2.16.1",
+        "@parcel/events": "2.16.1"
       },
       "engines": {
         "node": ">= 16.0.0"
@@ -589,9 +590,9 @@
       }
     },
     "node_modules/@parcel/markdown-ansi": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.15.4.tgz",
-      "integrity": "sha512-u5Lwcr4ZVBSLFbKYht+mJqJ3ZMXvJdmDMU5eDtrIEKPpu9LrIDdPpDEXBoyO6pDsoV/2AqyXUUMzBRyCatkkoQ==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.1.tgz",
+      "integrity": "sha512-4Qww9KkGrVrY/JyD2NtrdUmyufKOqGg3t6hkE4UqQBPb+GZd+TQi6i1mjWvOE6r9AF53x5PAZZ13f/HfllU2qA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -606,19 +607,19 @@
       }
     },
     "node_modules/@parcel/namer-default": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.15.4.tgz",
-      "integrity": "sha512-EXsoQ1S+5ZIfy8431E7F0vVS7bfH5JpZ+vFVcUpArJDkhmMG7T/eP6Kp9CXHLJmn7ki1x7iIVytrja0XXRQWBQ==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.16.1.tgz",
+      "integrity": "sha512-vs4djcAt3HoQri6g8itdCzFTiFXwcVNfFDqa9By1pTdq/aKWapJWZaes2KCf2ey2FoEafS0tOIA90n124PM00A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.15.4",
-        "@parcel/plugin": "2.15.4",
+        "@parcel/diagnostic": "2.16.1",
+        "@parcel/plugin": "2.16.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.4"
+        "parcel": "^2.16.1"
       },
       "funding": {
         "type": "opencollective",
@@ -626,17 +627,17 @@
       }
     },
     "node_modules/@parcel/node-resolver-core": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-3.6.4.tgz",
-      "integrity": "sha512-g3+usMnr7pfRqbMAksOpNA7GJk7HUNW1Wxx7Shhp4w0K9JUdVrd2LRKwZxbqL7H9NqWtVvUOT9cZbMlDR6bO1w==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-3.7.1.tgz",
+      "integrity": "sha512-xY+mzz1a5L22HvwkCHtt1fRZa8pD8znXLB8NLnqdu/xa7FGwWNgA2ukFPSlNGwwI5aw3jQylERP8Mr6/qLsefQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@mischnic/json-sourcemap": "^0.1.1",
-        "@parcel/diagnostic": "2.15.4",
-        "@parcel/fs": "2.15.4",
-        "@parcel/rust": "2.15.4",
-        "@parcel/utils": "2.15.4",
+        "@parcel/diagnostic": "2.16.1",
+        "@parcel/fs": "2.16.1",
+        "@parcel/rust": "2.16.1",
+        "@parcel/utils": "2.16.1",
         "nullthrows": "^1.1.1",
         "semver": "^7.7.1"
       },
@@ -649,23 +650,23 @@
       }
     },
     "node_modules/@parcel/optimizer-css": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.15.4.tgz",
-      "integrity": "sha512-KQLuqwcvVFTNFtM+bzfvQivwunmhVAngmR4NiI8zQaykidYH28V8YkVAQmpbLbgoGad/UgG7grb0UshvnrQHpw==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.16.1.tgz",
+      "integrity": "sha512-MIbeqxqcbtGksiNzIvFeMU++gsBl8MafQRghQxsB1kAMl49i+Cnj/Kp3qKkHd+Bb2XXlx7TagGtXCnCrtxdJjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.15.4",
-        "@parcel/plugin": "2.15.4",
+        "@parcel/diagnostic": "2.16.1",
+        "@parcel/plugin": "2.16.1",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.15.4",
+        "@parcel/utils": "2.16.1",
         "browserslist": "^4.24.5",
         "lightningcss": "^1.30.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.4"
+        "parcel": "^2.16.1"
       },
       "funding": {
         "type": "opencollective",
@@ -673,19 +674,19 @@
       }
     },
     "node_modules/@parcel/optimizer-html": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-html/-/optimizer-html-2.15.4.tgz",
-      "integrity": "sha512-gBvt6RdDVMyO1Flvdtc8DxpxLgIXhaKuVXEjHdAP7sEW0SMdSd6r/tl6Plmcszig7sDwhDf6IsQOIvbzGHYZZg==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-html/-/optimizer-html-2.16.1.tgz",
+      "integrity": "sha512-AwrecuOOuWqlon+rWJsQuXyJ70ivTbjm505NTBKoQYdVeEbO6pZYYeuF8ZKh0Qq+zOCy47397RgEuiuwLf9t2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.15.4",
-        "@parcel/rust": "2.15.4",
-        "@parcel/utils": "2.15.4"
+        "@parcel/plugin": "2.16.1",
+        "@parcel/rust": "2.16.1",
+        "@parcel/utils": "2.16.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.4"
+        "parcel": "^2.16.1"
       },
       "funding": {
         "type": "opencollective",
@@ -693,44 +694,44 @@
       }
     },
     "node_modules/@parcel/optimizer-image": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.15.4.tgz",
-      "integrity": "sha512-M8fo7eEL6JRcmLhSX9pUUGU4MPrPrE9cMNcwIt3DQLnSvQ+sshhUDa6t9hKWeHHhs16BHvxrvksN2TIbkgHODQ==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.16.1.tgz",
+      "integrity": "sha512-vlQW0DJQ0XTmM/rNwJUuLbTeB31CwyH2yb2RMZfByAGGodpy2vxt51NS/KyV1mNcJRBtW2Li+XVzYSb14dF5Bw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.15.4",
-        "@parcel/plugin": "2.15.4",
-        "@parcel/rust": "2.15.4",
-        "@parcel/utils": "2.15.4",
-        "@parcel/workers": "2.15.4"
+        "@parcel/diagnostic": "2.16.1",
+        "@parcel/plugin": "2.16.1",
+        "@parcel/rust": "2.16.1",
+        "@parcel/utils": "2.16.1",
+        "@parcel/workers": "2.16.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.4"
+        "parcel": "^2.16.1"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.15.4"
+        "@parcel/core": "^2.16.1"
       }
     },
     "node_modules/@parcel/optimizer-svg": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-svg/-/optimizer-svg-2.15.4.tgz",
-      "integrity": "sha512-pPdjRaLPqjAEROXIHLc6JWLLki56alhuUNbalhLqBCgktZrrq2dGCjBEVgxqRczc9D+ePCX/e/xci4tC0Tkcbg==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-svg/-/optimizer-svg-2.16.1.tgz",
+      "integrity": "sha512-dpAlCrbITPQr5RpuSjr91pfkQumxOzyiaRM39kMwjsTrYa2/F/JCoPKJZMSMyODvB9MZAz2qfGkWbj/Xb+a1NQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.15.4",
-        "@parcel/rust": "2.15.4",
-        "@parcel/utils": "2.15.4"
+        "@parcel/plugin": "2.16.1",
+        "@parcel/rust": "2.16.1",
+        "@parcel/utils": "2.16.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.4"
+        "parcel": "^2.16.1"
       },
       "funding": {
         "type": "opencollective",
@@ -738,22 +739,22 @@
       }
     },
     "node_modules/@parcel/optimizer-swc": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-swc/-/optimizer-swc-2.15.4.tgz",
-      "integrity": "sha512-2m5cYESVCq6AGx252eSTArZ1Oc1Ve4GBGL7NhvgbNqOthyXlc2qAed6rCkARrBd8pfEl5+2XHeK1ijDAZdIZ/A==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-swc/-/optimizer-swc-2.16.1.tgz",
+      "integrity": "sha512-mZtrISSio541K4IH0cT90c143YOvAhOs04RrBGs12WjtHOVTASt0V3gVhstP4W3HvtVNbkJ4mAtUiuC7xtuHJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.15.4",
-        "@parcel/plugin": "2.15.4",
+        "@parcel/diagnostic": "2.16.1",
+        "@parcel/plugin": "2.16.1",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.15.4",
+        "@parcel/utils": "2.16.1",
         "@swc/core": "^1.11.24",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.4"
+        "parcel": "^2.16.1"
       },
       "funding": {
         "type": "opencollective",
@@ -761,19 +762,19 @@
       }
     },
     "node_modules/@parcel/package-manager": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.15.4.tgz",
-      "integrity": "sha512-KZONBcEJ24moQdrpU0zJh9CYk3KKbpB5RUM70utAORem1yQKms+0Y4YED3njq6nZzbgwUN/Csc+powUHLZStvg==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.16.1.tgz",
+      "integrity": "sha512-HDMT0+L7kMBG+YgkxaNv/1nobFRgygte9e0QuYiSVMngdbYvXw9Yy8tEDeWEAOKWs0rGtPXJD6k9gP8/Aa3VQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.15.4",
-        "@parcel/fs": "2.15.4",
-        "@parcel/logger": "2.15.4",
-        "@parcel/node-resolver-core": "3.6.4",
-        "@parcel/types": "2.15.4",
-        "@parcel/utils": "2.15.4",
-        "@parcel/workers": "2.15.4",
+        "@parcel/diagnostic": "2.16.1",
+        "@parcel/fs": "2.16.1",
+        "@parcel/logger": "2.16.1",
+        "@parcel/node-resolver-core": "3.7.1",
+        "@parcel/types": "2.16.1",
+        "@parcel/utils": "2.16.1",
+        "@parcel/workers": "2.16.1",
         "@swc/core": "^1.11.24",
         "semver": "^7.7.1"
       },
@@ -785,26 +786,26 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.15.4"
+        "@parcel/core": "^2.16.1"
       }
     },
     "node_modules/@parcel/packager-css": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.15.4.tgz",
-      "integrity": "sha512-bzSaNf+I5lmJFu95wSG2k7pGwjCDesZsV6Y9sozIL2LoSxqvkGhm/ABXAa3Ed7dLe3tSAEBzJcyqShQgLzSzuw==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.16.1.tgz",
+      "integrity": "sha512-N4Ex89dqoprdDoSusM2qveQcpl9zdaQmZtW81xIMFK5+ruaBcKy6Rzyao8LWnbg4wfeNVE0zVkZEq7k3oxbCBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.15.4",
-        "@parcel/plugin": "2.15.4",
+        "@parcel/diagnostic": "2.16.1",
+        "@parcel/plugin": "2.16.1",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.15.4",
+        "@parcel/utils": "2.16.1",
         "lightningcss": "^1.30.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.4"
+        "parcel": "^2.16.1"
       },
       "funding": {
         "type": "opencollective",
@@ -812,20 +813,20 @@
       }
     },
     "node_modules/@parcel/packager-html": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.15.4.tgz",
-      "integrity": "sha512-Uayux6A2Anm66Kmq22QhD0TuVp9LiRCMuPUzBd6n4ekNlG0Lzm6K3/okMkPG65nKbNjq5qcPscFWlDxggvjt2g==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.16.1.tgz",
+      "integrity": "sha512-QleJQl63DC2AaIQ2rHS3d46zhGrIoxBz1QKDfgYoG+YxpG8nAKFgI3YBCMNwUYU4pVpNWxmLP/MRKNz9hVxL9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.15.4",
-        "@parcel/rust": "2.15.4",
-        "@parcel/types": "2.15.4",
-        "@parcel/utils": "2.15.4"
+        "@parcel/plugin": "2.16.1",
+        "@parcel/rust": "2.16.1",
+        "@parcel/types": "2.16.1",
+        "@parcel/utils": "2.16.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.4"
+        "parcel": "^2.16.1"
       },
       "funding": {
         "type": "opencollective",
@@ -833,24 +834,24 @@
       }
     },
     "node_modules/@parcel/packager-js": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.15.4.tgz",
-      "integrity": "sha512-96bqhs1jyd28CfWQD+Yn8rSsd1ar7voHWyBtMLimsK+bDJIzL26Z7jWyRDwXRuLErYC01EoXRIRctxtmeRVJ2Q==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.16.1.tgz",
+      "integrity": "sha512-jTxUhGVqZdierdjeGCJiuVBSBU8iVqp3A0BT/RCpcB0YYY3dymDHTQrAFw8h2kJ0ZcfQEr6BeFIU4RBTuM1xow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.15.4",
-        "@parcel/plugin": "2.15.4",
-        "@parcel/rust": "2.15.4",
+        "@parcel/diagnostic": "2.16.1",
+        "@parcel/plugin": "2.16.1",
+        "@parcel/rust": "2.16.1",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/types": "2.15.4",
-        "@parcel/utils": "2.15.4",
+        "@parcel/types": "2.16.1",
+        "@parcel/utils": "2.16.1",
         "globals": "^13.24.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.4"
+        "parcel": "^2.16.1"
       },
       "funding": {
         "type": "opencollective",
@@ -858,17 +859,17 @@
       }
     },
     "node_modules/@parcel/packager-raw": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.15.4.tgz",
-      "integrity": "sha512-CaSpDt5jjcO0SYCtsDhw6yfTDQuDFQ875H42W/ftvSQL7RfLRljPthnbdcy9chvKBbvRBQF+0z8Sxwehrd5hsA==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.16.1.tgz",
+      "integrity": "sha512-EYTGl4uKGu0HVFlCZtUcwo+aNr8/9BiXZyY1crd4SRF1cioKYpgLZKv31z1uNiaDrTxIRH8hWNnjPWAxj382NA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.15.4"
+        "@parcel/plugin": "2.16.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.4"
+        "parcel": "^2.16.1"
       },
       "funding": {
         "type": "opencollective",
@@ -876,20 +877,20 @@
       }
     },
     "node_modules/@parcel/packager-svg": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.15.4.tgz",
-      "integrity": "sha512-qHsyOgnzoA2XGMLIYUnX79XAaV327VTWQvIzju/OmOjcff4o3uiEcNL8w9k3p2w2oPXOLoQ0THMiivoUQSM8GQ==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.16.1.tgz",
+      "integrity": "sha512-DQJtFyjurSDu135vvDd0DDFjyaTS8eX9Gl8wS33fPh31PgeqbSYGSe6vtlIw5NHWSTgqvxGmwAf1HYY9WgEGTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.15.4",
-        "@parcel/rust": "2.15.4",
-        "@parcel/types": "2.15.4",
-        "@parcel/utils": "2.15.4"
+        "@parcel/plugin": "2.16.1",
+        "@parcel/rust": "2.16.1",
+        "@parcel/types": "2.16.1",
+        "@parcel/utils": "2.16.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.4"
+        "parcel": "^2.16.1"
       },
       "funding": {
         "type": "opencollective",
@@ -897,17 +898,17 @@
       }
     },
     "node_modules/@parcel/packager-wasm": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-wasm/-/packager-wasm-2.15.4.tgz",
-      "integrity": "sha512-YPVij7zrBchtXr/y29P4uh3C/+19PMhhLibYF/8oMJKkFkeU3Uv00/XLm915vdBPrIPjgw0YuIfLzUKip1uGtg==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-wasm/-/packager-wasm-2.16.1.tgz",
+      "integrity": "sha512-Do/5Cr4yckpWqeQyhiPqwDbbg+nwj20BGIP9edYIL9XAmCh8ARBwntFWmcSpeNdGp+DSJKQ28SgWCT/5cyyoig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.15.4"
+        "@parcel/plugin": "2.16.1"
       },
       "engines": {
         "node": ">=16.0.0",
-        "parcel": "^2.15.4"
+        "parcel": "^2.16.1"
       },
       "funding": {
         "type": "opencollective",
@@ -915,19 +916,19 @@
       }
     },
     "node_modules/@parcel/packager-webextension": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-webextension/-/packager-webextension-2.15.4.tgz",
-      "integrity": "sha512-25BYqdkB2KRONnYiPYK+lLvynWzkSHyXVciOA0KwdGcF02UwFGdG08D8ULiy/WkCVH+I9vUaipih0gVUb++AAA==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-webextension/-/packager-webextension-2.16.1.tgz",
+      "integrity": "sha512-3Bol7+75DJDmeC9q6+0dlRZ3lbNb5oUV/d4R3/bWGyTsjTh/SqsiFFa8YZUlhNNbNSFREA5cvpBC+NrBXnvfgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.15.4",
-        "@parcel/utils": "2.15.4",
+        "@parcel/plugin": "2.16.1",
+        "@parcel/utils": "2.16.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">=16.0.0",
-        "parcel": "^2.15.4"
+        "parcel": "^2.16.1"
       },
       "funding": {
         "type": "opencollective",
@@ -935,13 +936,13 @@
       }
     },
     "node_modules/@parcel/plugin": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.15.4.tgz",
-      "integrity": "sha512-XVehjmzk8ZDOFf/BXo26L76ZqCGNKIQcN2ngxAnq0KRY/WFanL8yLaL0qQq+c9whlu09hkGz1CuhFBLAIjJMYQ==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.16.1.tgz",
+      "integrity": "sha512-/5hdgMFjd4pRZelfzWVAEWEH51qCHGB6I3z4mV3i8Teh0zsOgoHJrn1t+sVYkhKPDOMs16XAkx2iCMvEcktDrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/types": "2.15.4"
+        "@parcel/types": "2.16.1"
       },
       "engines": {
         "node": ">= 16.0.0"
@@ -952,15 +953,15 @@
       }
     },
     "node_modules/@parcel/profiler": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/profiler/-/profiler-2.15.4.tgz",
-      "integrity": "sha512-ezVZlttUmQ1MQD5e8yVb07vSGYEFOB59Y/jaxL9mGSLZkVhMIIHe/7SuA+4qVAH8dlg6bslXRqlsunLMPEgPsg==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/profiler/-/profiler-2.16.1.tgz",
+      "integrity": "sha512-9VKswpixK5CggxqoEoThiusnRbqU48QIWwmGQhaTV9iBYi9m/LhEYUoTa8K/KQ70yJknghMMNc1JfAvt2bfh5w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.15.4",
-        "@parcel/events": "2.15.4",
-        "@parcel/types-internal": "2.15.4",
+        "@parcel/diagnostic": "2.16.1",
+        "@parcel/events": "2.16.1",
+        "@parcel/types-internal": "2.16.1",
         "chrome-trace-event": "^1.0.2"
       },
       "engines": {
@@ -972,21 +973,21 @@
       }
     },
     "node_modules/@parcel/reporter-cli": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.15.4.tgz",
-      "integrity": "sha512-us0HIwuJqpSguf+yi4n8foabVs26JGvRB/eSOf0KkRldxFciYLn4NJ8rt3Xm1zvxlDiSkD4v2n77u+ouIZ+AEQ==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.16.1.tgz",
+      "integrity": "sha512-+P4Nvg5a2GnOpsIf93U75JjPgltrAmGTCVyRpbeBo45uFBvHGKPX5O7Vn7rl1wWunNobOAxn6F9JxPCApcw79A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.15.4",
-        "@parcel/types": "2.15.4",
-        "@parcel/utils": "2.15.4",
+        "@parcel/plugin": "2.16.1",
+        "@parcel/types": "2.16.1",
+        "@parcel/utils": "2.16.1",
         "chalk": "^4.1.2",
         "term-size": "^2.2.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.4"
+        "parcel": "^2.16.1"
       },
       "funding": {
         "type": "opencollective",
@@ -994,20 +995,20 @@
       }
     },
     "node_modules/@parcel/reporter-dev-server": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.15.4.tgz",
-      "integrity": "sha512-uCNeDyArNNXI9YThlxyTx7+5ZSxlewyUdyrLdDZCqvn8s1xNB9W8sUNVps7mJZQSc+2ZRk3wyDemURD67uJk/A==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.16.1.tgz",
+      "integrity": "sha512-xTVhfnt3Se5BTLC/Dp4pBmytqdZcVyqDExJ39N9mi76/CW0XNDcMqRFACxQltu/ahxmUYYyFtpiXis5Daf9xzQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/codeframe": "2.15.4",
-        "@parcel/plugin": "2.15.4",
+        "@parcel/codeframe": "2.16.1",
+        "@parcel/plugin": "2.16.1",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.15.4"
+        "@parcel/utils": "2.16.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.4"
+        "parcel": "^2.16.1"
       },
       "funding": {
         "type": "opencollective",
@@ -1015,20 +1016,20 @@
       }
     },
     "node_modules/@parcel/reporter-tracer": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-tracer/-/reporter-tracer-2.15.4.tgz",
-      "integrity": "sha512-9W1xsb/FtobCQ4z847nI6hFDaTZHLeThv/z05EF77R30RX2k+unG9ac5NQB1v4KLx09Bhfre32+sjYNReWxWlg==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-tracer/-/reporter-tracer-2.16.1.tgz",
+      "integrity": "sha512-MDDzZx5j0yer+jTP/gBEPiMDzOAeKy7I0pLyPuntwKWnAiaG+TRaQPp8xXQhW6ZxIQIqsHkfUJoTksuFTla+tA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.15.4",
-        "@parcel/utils": "2.15.4",
+        "@parcel/plugin": "2.16.1",
+        "@parcel/utils": "2.16.1",
         "chrome-trace-event": "^1.0.3",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.4"
+        "parcel": "^2.16.1"
       },
       "funding": {
         "type": "opencollective",
@@ -1036,18 +1037,18 @@
       }
     },
     "node_modules/@parcel/resolver-default": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.15.4.tgz",
-      "integrity": "sha512-4uKo3FFnubtIc4rM9jZiQQXpa1slawyRy5btJEfTFvbcnz0dm3WThLrsPDMfmPwNr9F/n5x8yzDLI6/fZ/elgA==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.16.1.tgz",
+      "integrity": "sha512-UmnZClD4nWusNTpfC7WaNUfPNnNbjgrIR1l3kOAU+X/b/HJWczzMNIZGTw3rypV0df6XpQlrUrHc85NJ6aRlLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/node-resolver-core": "3.6.4",
-        "@parcel/plugin": "2.15.4"
+        "@parcel/node-resolver-core": "3.7.1",
+        "@parcel/plugin": "2.16.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.4"
+        "parcel": "^2.16.1"
       },
       "funding": {
         "type": "opencollective",
@@ -1055,18 +1056,18 @@
       }
     },
     "node_modules/@parcel/runtime-browser-hmr": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.15.4.tgz",
-      "integrity": "sha512-KRGzbxDUOQUkrJKxxY0WyU7oVaa9TvWTRlpuGJXzQJs/hw8vkAAoAm8+ptpypvBC8LnxFHzGbSyHPfL8C8MQOw==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.16.1.tgz",
+      "integrity": "sha512-W8Os+1ORHLJmzX+av76DQkyX4RLndhhB4u1o43P55UfAaV3URcc2I0tNQ/wZKA7qU2DhcdoXijMok7VRUfS0jw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.15.4",
-        "@parcel/utils": "2.15.4"
+        "@parcel/plugin": "2.16.1",
+        "@parcel/utils": "2.16.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.4"
+        "parcel": "^2.16.1"
       },
       "funding": {
         "type": "opencollective",
@@ -1074,20 +1075,20 @@
       }
     },
     "node_modules/@parcel/runtime-js": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.15.4.tgz",
-      "integrity": "sha512-zNRK+693CMkYiA0ckjPOmz+JVHD9bVzp27itcMyuDH6l/Or8m09RgCC4DIdIxBqiplsDSe39DwEc5X7b0vvcjw==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.16.1.tgz",
+      "integrity": "sha512-Ck7DJw1QmeYiQ17z0Q3mtDl6fH1VPrORmygb2CYcGAIOfIbvXV74vRss1NqpScU8QTjN0qpL4Ve8txwoISgIAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.15.4",
-        "@parcel/plugin": "2.15.4",
-        "@parcel/utils": "2.15.4",
+        "@parcel/diagnostic": "2.16.1",
+        "@parcel/plugin": "2.16.1",
+        "@parcel/utils": "2.16.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.4"
+        "parcel": "^2.16.1"
       },
       "funding": {
         "type": "opencollective",
@@ -1095,20 +1096,20 @@
       }
     },
     "node_modules/@parcel/runtime-rsc": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-rsc/-/runtime-rsc-2.15.4.tgz",
-      "integrity": "sha512-yHc4HEwzCQYLqa6Q1WtZ8xJeaDAk0p2i0b3ABq2I+izmRjer4jertlsEwh9mf9Z1eUGtJobdGYzl8Ai1VfhC3g==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-rsc/-/runtime-rsc-2.16.1.tgz",
+      "integrity": "sha512-waNc2gBWxfaUcvPtPAtjWwRLYLuMPHyu+JMgHV7txsv3JZnPNieUvTPbqeARbpsVpk2xTgFnAGS3HBfw5QW/Eg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.15.4",
-        "@parcel/rust": "2.15.4",
-        "@parcel/utils": "2.15.4",
+        "@parcel/plugin": "2.16.1",
+        "@parcel/rust": "2.16.1",
+        "@parcel/utils": "2.16.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.15.4"
+        "parcel": "^2.16.1"
       },
       "funding": {
         "type": "opencollective",
@@ -1116,19 +1117,19 @@
       }
     },
     "node_modules/@parcel/runtime-service-worker": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.15.4.tgz",
-      "integrity": "sha512-NGq/wS34GIVzo2ZURBjCqgHV+PU7eTcngCzmmk/wrCEeWnr13ld+CAIxVZoqyNJwYsF6VQanrjSM2/LhCXEdyA==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.16.1.tgz",
+      "integrity": "sha512-YiM/SS8rk/sBFdA8YFxlviO5FhAjzjBVAzzlnNG0qe3xLmqBfzHzW+RNf0/KblWRhxHCwmUDmzgE2ybaDeL3Lw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.15.4",
-        "@parcel/utils": "2.15.4",
+        "@parcel/plugin": "2.16.1",
+        "@parcel/utils": "2.16.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.4"
+        "parcel": "^2.16.1"
       },
       "funding": {
         "type": "opencollective",
@@ -1136,19 +1137,19 @@
       }
     },
     "node_modules/@parcel/runtime-webextension": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-webextension/-/runtime-webextension-2.15.4.tgz",
-      "integrity": "sha512-VZeOvRfbKuY6R3Azhx3HbLLr3aXxEHcFkv0RWijOwLItHW9liezNMIc2tUB4LSKjyGfWXJIoEGajUno+i3/lOQ==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-webextension/-/runtime-webextension-2.16.1.tgz",
+      "integrity": "sha512-a1PTPVbfp6rVlupjD3U4oBM1vpg83VDSFg7+D5Xgc7yXZA2T6+VTF5oD7vYZM2i/Biq2hbczqgmgEdlH+MAx1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.15.4",
-        "@parcel/utils": "2.15.4",
+        "@parcel/plugin": "2.16.1",
+        "@parcel/utils": "2.16.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.4"
+        "parcel": "^2.16.1"
       },
       "funding": {
         "type": "opencollective",
@@ -1156,9 +1157,9 @@
       }
     },
     "node_modules/@parcel/rust": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.15.4.tgz",
-      "integrity": "sha512-OxOux8z8YEYg23+15uMmYaloFp3x1RwcliBay6HqxUW7RTmtI1/z+xd8AtienCckACD60gvDGy04LjgbEGdJVg==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.1.tgz",
+      "integrity": "sha512-lQkf14MLKZSY/P8j1lrOgFvMCt95dO+VdXIIM2aHjbxnzYSIGgHIt2XDVtKULE+DexaYZbleA0tTnX8AABUIyQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1169,14 +1170,14 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "@parcel/rust-darwin-arm64": "2.15.4",
-        "@parcel/rust-darwin-x64": "2.15.4",
-        "@parcel/rust-linux-arm-gnueabihf": "2.15.4",
-        "@parcel/rust-linux-arm64-gnu": "2.15.4",
-        "@parcel/rust-linux-arm64-musl": "2.15.4",
-        "@parcel/rust-linux-x64-gnu": "2.15.4",
-        "@parcel/rust-linux-x64-musl": "2.15.4",
-        "@parcel/rust-win32-x64-msvc": "2.15.4"
+        "@parcel/rust-darwin-arm64": "2.16.1",
+        "@parcel/rust-darwin-x64": "2.16.1",
+        "@parcel/rust-linux-arm-gnueabihf": "2.16.1",
+        "@parcel/rust-linux-arm64-gnu": "2.16.1",
+        "@parcel/rust-linux-arm64-musl": "2.16.1",
+        "@parcel/rust-linux-x64-gnu": "2.16.1",
+        "@parcel/rust-linux-x64-musl": "2.16.1",
+        "@parcel/rust-win32-x64-msvc": "2.16.1"
       },
       "peerDependencies": {
         "napi-wasm": "^1.1.2"
@@ -1188,9 +1189,9 @@
       }
     },
     "node_modules/@parcel/rust-darwin-arm64": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.15.4.tgz",
-      "integrity": "sha512-cEpNDeEtvM5Nhj0QLN95QbcZ9yY6Z5W3+2OeHvnojEAP8Rp1XGzqVTTZdlyKyN1KTiyfzIOiQJCiEcr+kMc5Nw==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.1.tgz",
+      "integrity": "sha512-6J1pnznHYzH1TOQbDZmbGa6bXNW+KXbD+XIihvQOid42DLGJNXRmwMmCU3en/759lF/pfmzmR7sm6wPKaKGfbg==",
       "cpu": [
         "arm64"
       ],
@@ -1209,9 +1210,9 @@
       }
     },
     "node_modules/@parcel/rust-darwin-x64": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.15.4.tgz",
-      "integrity": "sha512-jL9i13sXKeBXXz8Z3BNYoScPOi+ljBA0ubAE3PN5DCoAA6wS4/FsAiRSIUw+3uxqASBD7+JvaT5sDUga1Xft5g==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.1.tgz",
+      "integrity": "sha512-NDZpxleSeJ0yPx4OobDcj+z5x6RzsWmuA1RXBDuCKhf2kyXKP3+kfmrQew/7Q0r9uKA5pqCIw0W4eFqy4IoqIA==",
       "cpu": [
         "x64"
       ],
@@ -1230,9 +1231,9 @@
       }
     },
     "node_modules/@parcel/rust-linux-arm-gnueabihf": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.15.4.tgz",
-      "integrity": "sha512-c8HpVdDugCutlMILoOlkTioih9HGJpQrzS2G3cg/O1a5ZTacooGf3eGJGoh6dUBEv9WEaEb6zsTRwFv2BgtZcA==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.1.tgz",
+      "integrity": "sha512-xLLcbMP38ya8/z5esp3ypN2htxO9AsY4uQqF2rigIUZ2abQwL4MPKxfVZtrExWdcrcWiFUbiwn3+GKu/0M9Yow==",
       "cpu": [
         "arm"
       ],
@@ -1251,9 +1252,9 @@
       }
     },
     "node_modules/@parcel/rust-linux-arm64-gnu": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.15.4.tgz",
-      "integrity": "sha512-Wcfs/JY4FnuLxQaU+VX2rI4j376Qo2LkZmq4zp9frnsajaAqmloVQfnbUkdnQPEL4I38eHXerzBX3LoXSxnZKA==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.1.tgz",
+      "integrity": "sha512-asZlimUq1wBmj2PDcoBSKD1SJvcLf1mXTcYGojOsA3dqkOOz7fGz7oubqZYn6IM+02cUDO4ekH+YBV6Eo7XlTg==",
       "cpu": [
         "arm64"
       ],
@@ -1272,9 +1273,9 @@
       }
     },
     "node_modules/@parcel/rust-linux-arm64-musl": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.15.4.tgz",
-      "integrity": "sha512-xf9HxosEn3dU5M0zDSXqBaG8rEjLThRdTYqpkxHW/qQGzy0Se+/ntg8PeDHsSG5E9OK8xrcKH46Lhaw0QBF/Zw==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.1.tgz",
+      "integrity": "sha512-japSgrHYDD+uNHQ8TEdEhpiWu0zWMVBE48W3HJ5FKkwUOY51whZa8w0lhYW88ykUDYtEEd1ipvflv0fSDFY1jw==",
       "cpu": [
         "arm64"
       ],
@@ -1293,9 +1294,9 @@
       }
     },
     "node_modules/@parcel/rust-linux-x64-gnu": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.15.4.tgz",
-      "integrity": "sha512-RigXVCFj6h0AXmkuxU61rfgYuW+PXBR6qSkR2I20yKnAXoMfxLaZy9YJ3sAPMEjT9zXgzGAX+3syItMF+bRjaw==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.1.tgz",
+      "integrity": "sha512-A2LHDou7QDsKn3qlE+DHTBFqnjk0Hy1dhVEJgPgvW4N0XMa4x2JEcnLI9oFZ4KDXyMLGs0H6/smZ88zSdFoF3w==",
       "cpu": [
         "x64"
       ],
@@ -1314,9 +1315,9 @@
       }
     },
     "node_modules/@parcel/rust-linux-x64-musl": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.15.4.tgz",
-      "integrity": "sha512-tHlRgonSr5ca8OvhbGzZUggCgCOirRz5dHhPSCm4ajMxeDMamwprq6lKy0sCNTXht4TXIEyugBcfEuRKEeVIBw==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.1.tgz",
+      "integrity": "sha512-C+WgGbmIV1XxXUgNJdXpfZazqizYBvy7aesh8Z74QrlY99an/puQufd4kSbvwySN5iMGPSpN0VlyAUjDZLv9rQ==",
       "cpu": [
         "x64"
       ],
@@ -1335,9 +1336,9 @@
       }
     },
     "node_modules/@parcel/rust-win32-x64-msvc": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.15.4.tgz",
-      "integrity": "sha512-YsX6vMl/bfyxqZSN7yiaZQKLoJKELSZYcvg8gIv4CF1xkaTdmfr6gvq2iCyoV+bwrodNohN4Xfl8r7Wniu1/UA==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.1.tgz",
+      "integrity": "sha512-m8LoaBJfw5nv/4elM/jNNhWL5/HqBHNQnrbnN89e8sxn4L/zv9bPoXqHOuZglXwyB5velw1MGonX9Be/aK00ag==",
       "cpu": [
         "x64"
       ],
@@ -1369,16 +1370,16 @@
       }
     },
     "node_modules/@parcel/transformer-babel": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.15.4.tgz",
-      "integrity": "sha512-rb4nqZcTLkLD3nvuYJ9wwNb8x6cajBK2l6csdYMLEI4516SkIzkO/gs2cZ9M5q+CMhxAqpdEnrwektbOtQQasg==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.16.1.tgz",
+      "integrity": "sha512-/wjA5RaptiRMp+IxYOMiGlKDaymiEpwMJOPFvW0kDjvhrl40SqGfP4GgY3jV3N2GdC5jBpesDvo2RYd4/xaT9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.15.4",
-        "@parcel/plugin": "2.15.4",
+        "@parcel/diagnostic": "2.16.1",
+        "@parcel/plugin": "2.16.1",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.15.4",
+        "@parcel/utils": "2.16.1",
         "browserslist": "^4.24.5",
         "json5": "^2.2.3",
         "nullthrows": "^1.1.1",
@@ -1386,7 +1387,7 @@
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.4"
+        "parcel": "^2.16.1"
       },
       "funding": {
         "type": "opencollective",
@@ -1394,23 +1395,23 @@
       }
     },
     "node_modules/@parcel/transformer-css": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.15.4.tgz",
-      "integrity": "sha512-6tVwSJsOssXgcB5XMAQGsexAffoBEi8GVql3YQqzI1EwVYs9zr+B5mfbesb4aWcegR02w99NHJYFP9CrOr3SWw==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.16.1.tgz",
+      "integrity": "sha512-4lcrJFE1EdZ2z0Px0ynH+Eajg1vIoZzdqqz2x3UgWrkYVM4WHpZe/w7r2OCafyuobhJR4XYKTqxIYdHo4xWpiw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.15.4",
-        "@parcel/plugin": "2.15.4",
+        "@parcel/diagnostic": "2.16.1",
+        "@parcel/plugin": "2.16.1",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.15.4",
+        "@parcel/utils": "2.16.1",
         "browserslist": "^4.24.5",
         "lightningcss": "^1.30.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.4"
+        "parcel": "^2.16.1"
       },
       "funding": {
         "type": "opencollective",
@@ -1418,19 +1419,19 @@
       }
     },
     "node_modules/@parcel/transformer-html": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.15.4.tgz",
-      "integrity": "sha512-gzYPbbyEuV8nzPojw86eD5Kf93AYUWcY8lu33gu0XHROJH7mq5MAwPwtb/U+EfpeCd0/oKbLzA2mkQksM1NncQ==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.16.1.tgz",
+      "integrity": "sha512-9OP4f5JSKeDMP1LGJx4BMcMTqiF+uc+3Sum4zrlMBN6EuhYlj02IpcsHMWxZuY0uow/nnwY+aB3X83Bk3AFC1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.15.4",
-        "@parcel/plugin": "2.15.4",
-        "@parcel/rust": "2.15.4"
+        "@parcel/diagnostic": "2.16.1",
+        "@parcel/plugin": "2.16.1",
+        "@parcel/rust": "2.16.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.4"
+        "parcel": "^2.16.1"
       },
       "funding": {
         "type": "opencollective",
@@ -1438,38 +1439,38 @@
       }
     },
     "node_modules/@parcel/transformer-image": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.15.4.tgz",
-      "integrity": "sha512-KOVwj2gKjUybuzHwarC/YVqRf3r2BD4/2ysckozj6DIji/bq3fd2rE9yqxWXO+zt918PsOSTzMKwRnaseaXLKQ==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.16.1.tgz",
+      "integrity": "sha512-VyV8LMIK+7jtELpHky9MhD1hZl6YQ9F7LWIsPhrJ938HJEDwEQbZmiAJmMY9IV5kBOhhF3eGXSr/uSFA/F+Wcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.15.4",
-        "@parcel/utils": "2.15.4",
-        "@parcel/workers": "2.15.4",
+        "@parcel/plugin": "2.16.1",
+        "@parcel/utils": "2.16.1",
+        "@parcel/workers": "2.16.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.4"
+        "parcel": "^2.16.1"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.15.4"
+        "@parcel/core": "^2.16.1"
       }
     },
     "node_modules/@parcel/transformer-js": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.15.4.tgz",
-      "integrity": "sha512-HX76PalPjqCLmXJnuSeMr2km8WlnUsW8oaRZ6FuZtSo9QD8BqIcwKGxSbIy9JHkObBgmrMOVpGtYrJM4/BlYbg==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.16.1.tgz",
+      "integrity": "sha512-GPQ3X9UqrlLDBg06u7rG+IZNT9Kl+7+6gY7qJkrw4If1JnmW5O+xVR8zHe/P+6BvxJnOg0iFqzUueZacYHmHzw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.15.4",
-        "@parcel/plugin": "2.15.4",
-        "@parcel/rust": "2.15.4",
+        "@parcel/diagnostic": "2.16.1",
+        "@parcel/plugin": "2.16.1",
+        "@parcel/rust": "2.16.1",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.15.4",
-        "@parcel/workers": "2.15.4",
+        "@parcel/utils": "2.16.1",
+        "@parcel/workers": "2.16.1",
         "@swc/helpers": "^0.5.0",
         "browserslist": "^4.24.5",
         "nullthrows": "^1.1.1",
@@ -1478,29 +1479,29 @@
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.4"
+        "parcel": "^2.16.1"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.15.4"
+        "@parcel/core": "^2.16.1"
       }
     },
     "node_modules/@parcel/transformer-json": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.15.4.tgz",
-      "integrity": "sha512-1ASeOSH3gPeaXyy/TZ7ce2TOfJ3ZeK5SBnDs+MM8LFcQsTwdRJKjX/4Qq9RgtMRryYAGHgMa09Gvp9FuFRyd+w==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.16.1.tgz",
+      "integrity": "sha512-LdRdPZiBPvSKHr0KeDnLpGxqPen1OV3nvkrjZex28TluaiHFLPOCC4AQOcJ4xhDNPCzt1bONjJ6QhkYjfogNqw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.15.4",
+        "@parcel/plugin": "2.16.1",
         "json5": "^2.2.3"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.4"
+        "parcel": "^2.16.1"
       },
       "funding": {
         "type": "opencollective",
@@ -1508,17 +1509,17 @@
       }
     },
     "node_modules/@parcel/transformer-node": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-node/-/transformer-node-2.15.4.tgz",
-      "integrity": "sha512-zV5jvZA971eQMcFtaWZkW1UfAH/G6XVM/87oJ2B4ip9o9aKUWIl296rrfg2xWxUQyPhy11B17CJ6b8NgieqqrQ==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-node/-/transformer-node-2.16.1.tgz",
+      "integrity": "sha512-gclbMgvT8jNyTMFb5PeH0wni8N66dGMWgy381HZrRbkcb4KAw+PGLznrDng72Qyo/OxvEwK/IVkACz6EVoBygA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.15.4"
+        "@parcel/plugin": "2.16.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.4"
+        "parcel": "^2.16.1"
       },
       "funding": {
         "type": "opencollective",
@@ -1526,16 +1527,16 @@
       }
     },
     "node_modules/@parcel/transformer-postcss": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.15.4.tgz",
-      "integrity": "sha512-cNueSpOj3ulmMX85xr9clh/t0+mzVE+Q3H7Cf/OammqUkG/xjmilq4q7ZTgQFyUtUdWpE9LWWHojbJuz6k2Ulw==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.16.1.tgz",
+      "integrity": "sha512-fw252N0Lx3sZ2+XwiwhAD1350k5wx0Ez4c83wm8cVMsMSV4qW5LHFmfh2+2iHYxbUj0vqCPCmo1hoiNvmixqKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.15.4",
-        "@parcel/plugin": "2.15.4",
-        "@parcel/rust": "2.15.4",
-        "@parcel/utils": "2.15.4",
+        "@parcel/diagnostic": "2.16.1",
+        "@parcel/plugin": "2.16.1",
+        "@parcel/rust": "2.16.1",
+        "@parcel/utils": "2.16.1",
         "clone": "^2.1.2",
         "nullthrows": "^1.1.1",
         "postcss-value-parser": "^4.2.0",
@@ -1543,7 +1544,7 @@
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.4"
+        "parcel": "^2.16.1"
       },
       "funding": {
         "type": "opencollective",
@@ -1551,18 +1552,18 @@
       }
     },
     "node_modules/@parcel/transformer-posthtml": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.15.4.tgz",
-      "integrity": "sha512-dETI+CeKMwu5Dpvu8BrQtex6nwzbNWKQkXseiM5x6+Wf3j9RD2NVpAMBRMjLkw1XlC9Whz1egxLSgKlMKbjg0w==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.16.1.tgz",
+      "integrity": "sha512-QUdA4Q3nw2WPPkFeVzvTxq4tOkAxOmm1miP8FjXTeM6kOoYI296HIhqqMhiXj6BZ4J+zc/J+WpUCkYFDfEWScA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.15.4",
-        "@parcel/utils": "2.15.4"
+        "@parcel/plugin": "2.16.1",
+        "@parcel/utils": "2.16.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.4"
+        "parcel": "^2.16.1"
       },
       "funding": {
         "type": "opencollective",
@@ -1570,17 +1571,17 @@
       }
     },
     "node_modules/@parcel/transformer-raw": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.15.4.tgz",
-      "integrity": "sha512-pY2j09UCW2v1fwQtVLlCztSdPOxhq0YcWmTHCk/mRp8zuUR+eyHgsz48FrUxRF7cr/EBjc0zlFcregRMRcaTMg==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.16.1.tgz",
+      "integrity": "sha512-wiNtbiXsXpdHNO1hGqTQNYQKKuwGcfz7pL/3Em+ucyqeaURXhRQVs5QIwCGIvHiVlS/5OrxPoVWSNA6d0oicAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.15.4"
+        "@parcel/plugin": "2.16.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.4"
+        "parcel": "^2.16.1"
       },
       "funding": {
         "type": "opencollective",
@@ -1588,20 +1589,20 @@
       }
     },
     "node_modules/@parcel/transformer-react-refresh-wrap": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.15.4.tgz",
-      "integrity": "sha512-MgoQrV8+BVjrczAns5ZZbTERGB3/U4MaCBmbg3CuiTiIyS8IJQnGi+OhYRdKAB4NlsgpMZ5T2JrRbQUIm9MM8Q==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.16.1.tgz",
+      "integrity": "sha512-mUIA80/KtT3lz1Zep0t5VDqndSg0pqnkVdpBAn3QUABtT/2KR6Kr6YxFsxGAAN0BZ+Xnx92uPmQjhlkviVAk6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/error-overlay": "2.15.4",
-        "@parcel/plugin": "2.15.4",
-        "@parcel/utils": "2.15.4",
+        "@parcel/error-overlay": "2.16.1",
+        "@parcel/plugin": "2.16.1",
+        "@parcel/utils": "2.16.1",
         "react-refresh": "^0.16.0"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.4"
+        "parcel": "^2.16.1"
       },
       "funding": {
         "type": "opencollective",
@@ -1609,19 +1610,19 @@
       }
     },
     "node_modules/@parcel/transformer-svg": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.15.4.tgz",
-      "integrity": "sha512-Q22e0VRbx62VXFlvJWIlc8ihlLaPQgtnAZz5E1/+ojiNb+k0PmIRjNJclVWPF6IdCsLO5tnGfUOaXe2OnZz28Q==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.16.1.tgz",
+      "integrity": "sha512-OBB0kDjDAAgNzcVqxo/igd+iQL3EDbo8C36JzvH07zR72OXErAdJhTdgtfRq4fqFtMyLyBLT/s3Z37c1GzLoCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.15.4",
-        "@parcel/plugin": "2.15.4",
-        "@parcel/rust": "2.15.4"
+        "@parcel/diagnostic": "2.16.1",
+        "@parcel/plugin": "2.16.1",
+        "@parcel/rust": "2.16.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.15.4"
+        "parcel": "^2.16.1"
       },
       "funding": {
         "type": "opencollective",
@@ -1629,20 +1630,20 @@
       }
     },
     "node_modules/@parcel/transformer-webextension": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-webextension/-/transformer-webextension-2.15.4.tgz",
-      "integrity": "sha512-mUyfbROaHzPa9+9B8yga7/FzLeuXNgVexc8pTaO1cVsCnnp9cUjh3RTwSSMI6rlV+qqvUDug0QyHLPGP0mdtPQ==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-webextension/-/transformer-webextension-2.16.1.tgz",
+      "integrity": "sha512-lf6XWqlsctdCCbIrjkTNTlW1ZHEt0SQ3ItM4mvzFBel/EvDSZWVMyxx38X6mID++Sp8Nw+VdzGk8nc0JLPvlUA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@mischnic/json-sourcemap": "^0.1.1",
-        "@parcel/diagnostic": "2.15.4",
-        "@parcel/plugin": "2.15.4",
-        "@parcel/utils": "2.15.4",
+        "@parcel/diagnostic": "2.16.1",
+        "@parcel/plugin": "2.16.1",
+        "@parcel/utils": "2.16.1",
         "content-security-policy-parser": "^0.6.0"
       },
       "engines": {
-        "parcel": "^2.15.4"
+        "parcel": "^2.16.1"
       },
       "funding": {
         "type": "opencollective",
@@ -1650,41 +1651,41 @@
       }
     },
     "node_modules/@parcel/types": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.15.4.tgz",
-      "integrity": "sha512-fS3UMMinLtzn/NTSx/qx38saBgRniylldh0XZEUcGeME4D2Llu/QlLv+YZ/LJqrFci3fPRM+YAn2K+JT/u+/0w==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.16.1.tgz",
+      "integrity": "sha512-RFeomuzV/0Ze0jyzzx0u/eB4bXX6ISxrARA3k/3c7MQ+jaoY67+ELd8FwPV6ZmLqvvYIFdGiCZl6ascCABKwgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/types-internal": "2.15.4",
-        "@parcel/workers": "2.15.4"
+        "@parcel/types-internal": "2.16.1",
+        "@parcel/workers": "2.16.1"
       }
     },
     "node_modules/@parcel/types-internal": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.15.4.tgz",
-      "integrity": "sha512-kl5QEZ8PTWRvMkwmk7IG3VpP/5/MSGwt9Nrj9ctXLdZkDdXZpK7IbXAthLQ4zrByMaqZULL2IyDuBqBgfuAqlQ==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.16.1.tgz",
+      "integrity": "sha512-HVCHm0uFyJMsu30bAfm/pd0RNsXRWX0mUXaDHzGJRZ2Yer53JA6elRwkgrPz1KosBA+OuNU/G8atXfCxPMXdKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.15.4",
-        "@parcel/feature-flags": "2.15.4",
+        "@parcel/diagnostic": "2.16.1",
+        "@parcel/feature-flags": "2.16.1",
         "@parcel/source-map": "^2.1.1",
         "utility-types": "^3.11.0"
       }
     },
     "node_modules/@parcel/utils": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.15.4.tgz",
-      "integrity": "sha512-29m09sfPx0GHnmy1kkZ5XezprepdFGKKKUEJkyiYA4ERf55jjdnU2/GP4sWlZXxjh2Y+JFoCAFlCamEClq/8eA==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.1.tgz",
+      "integrity": "sha512-aoY6SCfAY7X6L39PFOsWNNcAobmJr4AJEgco+PJ2UAPFiHhkBZfUofXCwna5GHH5uqXZx6u3rAHiCUrM3bEDXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/codeframe": "2.15.4",
-        "@parcel/diagnostic": "2.15.4",
-        "@parcel/logger": "2.15.4",
-        "@parcel/markdown-ansi": "2.15.4",
-        "@parcel/rust": "2.15.4",
+        "@parcel/codeframe": "2.16.1",
+        "@parcel/diagnostic": "2.16.1",
+        "@parcel/logger": "2.16.1",
+        "@parcel/markdown-ansi": "2.16.1",
+        "@parcel/rust": "2.16.1",
         "@parcel/source-map": "^2.1.1",
         "chalk": "^4.1.2",
         "nullthrows": "^1.1.1"
@@ -2007,17 +2008,17 @@
       }
     },
     "node_modules/@parcel/workers": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.15.4.tgz",
-      "integrity": "sha512-wZ/5/mfjs5aeqhXY0c6fwuaBFeNpOXoOq2CKPSMDXt+GX2u/9/1bpVxN9XeGTAJO+ZD++CLq0hyzTnIHy58nyw==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.16.1.tgz",
+      "integrity": "sha512-yEUAjBrSgo5MYAAQbncYbw1m9WrNiJs+xKdfdHNUrOHlT7G+v62HJAZJWJsvyGQBE2nchSO+bEPgv+kxAF8mIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.15.4",
-        "@parcel/logger": "2.15.4",
-        "@parcel/profiler": "2.15.4",
-        "@parcel/types-internal": "2.15.4",
-        "@parcel/utils": "2.15.4",
+        "@parcel/diagnostic": "2.16.1",
+        "@parcel/logger": "2.16.1",
+        "@parcel/profiler": "2.16.1",
+        "@parcel/types-internal": "2.16.1",
+        "@parcel/utils": "2.16.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -2028,19 +2029,19 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.15.4"
+        "@parcel/core": "^2.16.1"
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.12.7",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.12.7.tgz",
-      "integrity": "sha512-bcpllEihyUSnqp0UtXTvXc19CT4wp3tGWLENhWnjr4B5iEOkzqMu+xHGz1FI5IBatjfqOQb29tgIfv6IL05QaA==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.2.tgz",
+      "integrity": "sha512-OQm+yJdXxvSjqGeaWhP6Ia264ogifwAO7Q12uTDVYj/Ks4jBTI4JknlcjDRAXtRhqbWsfbZyK/5RtuIPyptk3w==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3",
-        "@swc/types": "^0.1.23"
+        "@swc/types": "^0.1.25"
       },
       "engines": {
         "node": ">=10"
@@ -2050,16 +2051,16 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.12.7",
-        "@swc/core-darwin-x64": "1.12.7",
-        "@swc/core-linux-arm-gnueabihf": "1.12.7",
-        "@swc/core-linux-arm64-gnu": "1.12.7",
-        "@swc/core-linux-arm64-musl": "1.12.7",
-        "@swc/core-linux-x64-gnu": "1.12.7",
-        "@swc/core-linux-x64-musl": "1.12.7",
-        "@swc/core-win32-arm64-msvc": "1.12.7",
-        "@swc/core-win32-ia32-msvc": "1.12.7",
-        "@swc/core-win32-x64-msvc": "1.12.7"
+        "@swc/core-darwin-arm64": "1.15.2",
+        "@swc/core-darwin-x64": "1.15.2",
+        "@swc/core-linux-arm-gnueabihf": "1.15.2",
+        "@swc/core-linux-arm64-gnu": "1.15.2",
+        "@swc/core-linux-arm64-musl": "1.15.2",
+        "@swc/core-linux-x64-gnu": "1.15.2",
+        "@swc/core-linux-x64-musl": "1.15.2",
+        "@swc/core-win32-arm64-msvc": "1.15.2",
+        "@swc/core-win32-ia32-msvc": "1.15.2",
+        "@swc/core-win32-x64-msvc": "1.15.2"
       },
       "peerDependencies": {
         "@swc/helpers": ">=0.5.17"
@@ -2071,9 +2072,9 @@
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.12.7",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.12.7.tgz",
-      "integrity": "sha512-w6BBT0hBRS56yS+LbReVym0h+iB7/PpCddqrn1ha94ra4rZ4R/A91A/rkv+LnQlPqU/+fhqdlXtCJU9mrhCBtA==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.2.tgz",
+      "integrity": "sha512-Ghyz4RJv4zyXzrUC1B2MLQBbppIB5c4jMZJybX2ebdEQAvryEKp3gq1kBksCNsatKGmEgXul88SETU19sMWcrw==",
       "cpu": [
         "arm64"
       ],
@@ -2088,9 +2089,9 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.12.7",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.12.7.tgz",
-      "integrity": "sha512-jN6LhFfGOpm4DY2mXPgwH4aa9GLOwublwMVFFZ/bGnHYYCRitLZs9+JWBbyWs7MyGcA246Ew+EREx36KVEAxjA==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.2.tgz",
+      "integrity": "sha512-7n/PGJOcL2QoptzL42L5xFFfXY5rFxLHnuz1foU+4ruUTG8x2IebGhtwVTpaDN8ShEv2UZObBlT1rrXTba15Zw==",
       "cpu": [
         "x64"
       ],
@@ -2105,9 +2106,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.12.7",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.12.7.tgz",
-      "integrity": "sha512-rHn8XXi7G2StEtZRAeJ6c7nhJPDnqsHXmeNrAaYwk8Tvpa6ZYG2nT9E1OQNXj1/dfbSFTjdiA8M8ZvGYBlpBoA==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.2.tgz",
+      "integrity": "sha512-ZUQVCfRJ9wimuxkStRSlLwqX4TEDmv6/J+E6FicGkQ6ssLMWoKDy0cAo93HiWt/TWEee5vFhFaSQYzCuBEGO6A==",
       "cpu": [
         "arm"
       ],
@@ -2122,9 +2123,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.12.7",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.12.7.tgz",
-      "integrity": "sha512-N15hKizSSh+hkZ2x3TDVrxq0TDcbvDbkQJi2ZrLb9fK+NdFUV/x+XF16ZDPlbxtrGXl1CT7VD439SNaMN9F7qw==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.2.tgz",
+      "integrity": "sha512-GZh3pYBmfnpQ+JIg+TqLuz+pM+Mjsk5VOzi8nwKn/m+GvQBsxD5ectRtxuWUxMGNG8h0lMy4SnHRqdK3/iJl7A==",
       "cpu": [
         "arm64"
       ],
@@ -2139,9 +2140,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.12.7",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.12.7.tgz",
-      "integrity": "sha512-jxyINtBezpxd3eIUDiDXv7UQ87YWlPsM9KumOwJk09FkFSO4oYxV2RT+Wu+Nt5tVWue4N0MdXT/p7SQsDEk4YA==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.2.tgz",
+      "integrity": "sha512-5av6VYZZeneiYIodwzGMlnyVakpuYZryGzFIbgu1XP8wVylZxduEzup4eP8atiMDFmIm+s4wn8GySJmYqeJC0A==",
       "cpu": [
         "arm64"
       ],
@@ -2156,9 +2157,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.12.7",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.12.7.tgz",
-      "integrity": "sha512-PR4tPVwU1BQBfFDk2XfzXxsEIjF3x/bOV1BzZpYvrlkU0TKUDbR4t2wzvsYwD/coW7/yoQmlL70/qnuPtTp1Zw==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.2.tgz",
+      "integrity": "sha512-1nO/UfdCLuT/uE/7oB3EZgTeZDCIa6nL72cFEpdegnqpJVNDI6Qb8U4g/4lfVPkmHq2lvxQ0L+n+JdgaZLhrRA==",
       "cpu": [
         "x64"
       ],
@@ -2173,9 +2174,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.12.7",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.12.7.tgz",
-      "integrity": "sha512-zy7JWfQtQItgMfUjSbbcS3DZqQUn2d9VuV0LSGpJxtTXwgzhRpF1S2Sj7cU9hGpbM27Y8RJ4DeFb3qbAufjbrw==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.2.tgz",
+      "integrity": "sha512-Ksfrb0Tx310kr+TLiUOvB/I80lyZ3lSOp6cM18zmNRT/92NB4mW8oX2Jo7K4eVEI2JWyaQUAFubDSha2Q+439A==",
       "cpu": [
         "x64"
       ],
@@ -2190,9 +2191,9 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.12.7",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.12.7.tgz",
-      "integrity": "sha512-52PeF0tyX04ZFD8nibNhy/GjMFOZWTEWPmIB3wpD1vIJ1po+smtBnEdRRll5WIXITKoiND8AeHlBNBPqcsdcwA==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.2.tgz",
+      "integrity": "sha512-IzUb5RlMUY0r1A9IuJrQ7Tbts1wWb73/zXVXT8VhewbHGoNlBKE0qUhKMED6Tv4wDF+pmbtUJmKXDthytAvLmg==",
       "cpu": [
         "arm64"
       ],
@@ -2207,9 +2208,9 @@
       }
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.12.7",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.12.7.tgz",
-      "integrity": "sha512-WzQwkNMuhB1qQShT9uUgz/mX2j7NIEPExEtzvGsBT7TlZ9j1kGZ8NJcZH/fwOFcSJL4W7DnkL7nAhx6DBlSPaA==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.2.tgz",
+      "integrity": "sha512-kCATEzuY2LP9AlbU2uScjcVhgnCAkRdu62vbce17Ro5kxEHxYWcugkveyBRS3AqZGtwAKYbMAuNloer9LS/hpw==",
       "cpu": [
         "ia32"
       ],
@@ -2224,9 +2225,9 @@
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.12.7",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.12.7.tgz",
-      "integrity": "sha512-R52ivBi2lgjl+Bd3XCPum0YfgbZq/W1AUExITysddP9ErsNSwnreYyNB3exEijiazWGcqHEas2ChiuMOP7NYrA==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.2.tgz",
+      "integrity": "sha512-iJaHeYCF4jTn7OEKSa3KRiuVFIVYts8jYjNmCdyz1u5g8HRyTDISD76r8+ljEOgm36oviRQvcXaw6LFp1m0yyA==",
       "cpu": [
         "x64"
       ],
@@ -2258,9 +2259,9 @@
       }
     },
     "node_modules/@swc/types": {
-      "version": "0.1.23",
-      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.23.tgz",
-      "integrity": "sha512-u1iIVZV9Q0jxY+yM2vw/hZGDNudsN85bBpTqzAQ9rzkxW9D+e3aEM4Han+ow518gSewkXgjmEK0BD79ZcNVgPw==",
+      "version": "0.1.25",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.25.tgz",
+      "integrity": "sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2436,6 +2437,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -3112,9 +3114,9 @@
       }
     },
     "node_modules/lightningcss": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.1.tgz",
-      "integrity": "sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==",
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.2.tgz",
+      "integrity": "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
@@ -3128,22 +3130,44 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-darwin-arm64": "1.30.1",
-        "lightningcss-darwin-x64": "1.30.1",
-        "lightningcss-freebsd-x64": "1.30.1",
-        "lightningcss-linux-arm-gnueabihf": "1.30.1",
-        "lightningcss-linux-arm64-gnu": "1.30.1",
-        "lightningcss-linux-arm64-musl": "1.30.1",
-        "lightningcss-linux-x64-gnu": "1.30.1",
-        "lightningcss-linux-x64-musl": "1.30.1",
-        "lightningcss-win32-arm64-msvc": "1.30.1",
-        "lightningcss-win32-x64-msvc": "1.30.1"
+        "lightningcss-android-arm64": "1.30.2",
+        "lightningcss-darwin-arm64": "1.30.2",
+        "lightningcss-darwin-x64": "1.30.2",
+        "lightningcss-freebsd-x64": "1.30.2",
+        "lightningcss-linux-arm-gnueabihf": "1.30.2",
+        "lightningcss-linux-arm64-gnu": "1.30.2",
+        "lightningcss-linux-arm64-musl": "1.30.2",
+        "lightningcss-linux-x64-gnu": "1.30.2",
+        "lightningcss-linux-x64-musl": "1.30.2",
+        "lightningcss-win32-arm64-msvc": "1.30.2",
+        "lightningcss-win32-x64-msvc": "1.30.2"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.30.2.tgz",
+      "integrity": "sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.1.tgz",
-      "integrity": "sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ==",
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.2.tgz",
+      "integrity": "sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA==",
       "cpu": [
         "arm64"
       ],
@@ -3162,9 +3186,9 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.1.tgz",
-      "integrity": "sha512-k1EvjakfumAQoTfcXUcHQZhSpLlkAuEkdMBsI/ivWw9hL+7FtilQc0Cy3hrx0AAQrVtQAbMI7YjCgYgvn37PzA==",
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.2.tgz",
+      "integrity": "sha512-oBZgKchomuDYxr7ilwLcyms6BCyLn0z8J0+ZZmfpjwg9fRVZIR5/GMXd7r9RH94iDhld3UmSjBM6nXWM2TfZTQ==",
       "cpu": [
         "x64"
       ],
@@ -3183,9 +3207,9 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.1.tgz",
-      "integrity": "sha512-kmW6UGCGg2PcyUE59K5r0kWfKPAVy4SltVeut+umLCFoJ53RdCUWxcRDzO1eTaxf/7Q2H7LTquFHPL5R+Gjyig==",
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.2.tgz",
+      "integrity": "sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA==",
       "cpu": [
         "x64"
       ],
@@ -3204,9 +3228,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.1.tgz",
-      "integrity": "sha512-MjxUShl1v8pit+6D/zSPq9S9dQ2NPFSQwGvxBCYaBYLPlCWuPh9/t1MRS8iUaR8i+a6w7aps+B4N0S1TYP/R+Q==",
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.2.tgz",
+      "integrity": "sha512-eVdpxh4wYcm0PofJIZVuYuLiqBIakQ9uFZmipf6LF/HRj5Bgm0eb3qL/mr1smyXIS1twwOxNWndd8z0E374hiA==",
       "cpu": [
         "arm"
       ],
@@ -3225,9 +3249,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.1.tgz",
-      "integrity": "sha512-gB72maP8rmrKsnKYy8XUuXi/4OctJiuQjcuqWNlJQ6jZiWqtPvqFziskH3hnajfvKB27ynbVCucKSm2rkQp4Bw==",
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.2.tgz",
+      "integrity": "sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==",
       "cpu": [
         "arm64"
       ],
@@ -3246,9 +3270,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.1.tgz",
-      "integrity": "sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==",
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.2.tgz",
+      "integrity": "sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==",
       "cpu": [
         "arm64"
       ],
@@ -3267,9 +3291,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.1.tgz",
-      "integrity": "sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==",
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.2.tgz",
+      "integrity": "sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==",
       "cpu": [
         "x64"
       ],
@@ -3288,9 +3312,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.1.tgz",
-      "integrity": "sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==",
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.2.tgz",
+      "integrity": "sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==",
       "cpu": [
         "x64"
       ],
@@ -3309,9 +3333,9 @@
       }
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.1.tgz",
-      "integrity": "sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==",
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.2.tgz",
+      "integrity": "sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==",
       "cpu": [
         "arm64"
       ],
@@ -3330,9 +3354,9 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.1.tgz",
-      "integrity": "sha512-PVqXh48wh4T53F/1CCu8PIPCxLzWyCnn/9T5W1Jpmdy5h9Cwd+0YQS6/LwhHXSafuc61/xg9Lv5OrCby6a++jg==",
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.2.tgz",
+      "integrity": "sha512-5g1yc73p+iAkid5phb4oVFMB45417DkRevRbt/El/gKXJk4jid+vPFF/AXbxn05Aky8PapwzZrdJShv5C0avjw==",
       "cpu": [
         "x64"
       ],
@@ -3351,9 +3375,9 @@
       }
     },
     "node_modules/lightningcss/node_modules/detect-libc": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
-      "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -3436,9 +3460,10 @@
       }
     },
     "node_modules/min-document": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
-      "integrity": "sha512-9Wy1B3m3f66bPPmU5hdA4DR4PB2OfDU/+GS3yAB7IQozE3tqXaVv2zOjgla7MEGSRv95+ILmOuvhLkOK6wJtCQ==",
+      "version": "2.19.2",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.2.tgz",
+      "integrity": "sha512-8S5I8db/uZN8r9HSLFVWPdJCvYOejMcEC82VIzNUc6Zkklf/d1gg2psfE79/vyhWOj4+J8MtwmoOz3TmvaGu5A==",
+      "license": "MIT",
       "dependencies": {
         "dom-walk": "^0.1.0"
       }
@@ -3454,9 +3479,9 @@
       }
     },
     "node_modules/msgpackr": {
-      "version": "1.11.4",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.4.tgz",
-      "integrity": "sha512-uaff7RG9VIC4jacFW9xzL3jc0iM32DNHe4jYVycBcjUePT/Klnfj7pqtWJt9khvDFizmjN2TlYniYmSS2LIaZg==",
+      "version": "1.11.5",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.5.tgz",
+      "integrity": "sha512-UjkUHN0yqp9RWKy0Lplhh+wlpdt9oQBYgULZOiFhV3VclSF1JnSQWZ5r9gORQlNYaUKQoR8itv7g7z1xDDuACA==",
       "dev": true,
       "license": "MIT",
       "optionalDependencies": {
@@ -3487,9 +3512,9 @@
       }
     },
     "node_modules/msgpackr-extract/node_modules/detect-libc": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
-      "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -3525,7 +3550,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -3563,9 +3587,9 @@
       }
     },
     "node_modules/node-gyp-build-optional-packages/node_modules/detect-libc": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
-      "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -3640,24 +3664,24 @@
       }
     },
     "node_modules/parcel": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.15.4.tgz",
-      "integrity": "sha512-eZHQ/omuQ7yBYB9XezyzSqhc826oy/uhloCNiej1CTZ+twAqJVtp4MRvTGMcivKhE+WE8QkYD5XkJHLLQsJQcg==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.16.1.tgz",
+      "integrity": "sha512-VImOEXHLdrSuG6/jX2DucrCSju/idmtLUhwS5cCy7CrWDDA1af7qdHHD038kHYXWqUIAmzHkRsp/8oRxBqNfVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/config-default": "2.15.4",
-        "@parcel/core": "2.15.4",
-        "@parcel/diagnostic": "2.15.4",
-        "@parcel/events": "2.15.4",
-        "@parcel/feature-flags": "2.15.4",
-        "@parcel/fs": "2.15.4",
-        "@parcel/logger": "2.15.4",
-        "@parcel/package-manager": "2.15.4",
-        "@parcel/reporter-cli": "2.15.4",
-        "@parcel/reporter-dev-server": "2.15.4",
-        "@parcel/reporter-tracer": "2.15.4",
-        "@parcel/utils": "2.15.4",
+        "@parcel/config-default": "2.16.1",
+        "@parcel/core": "2.16.1",
+        "@parcel/diagnostic": "2.16.1",
+        "@parcel/events": "2.16.1",
+        "@parcel/feature-flags": "2.16.1",
+        "@parcel/fs": "2.16.1",
+        "@parcel/logger": "2.16.1",
+        "@parcel/package-manager": "2.16.1",
+        "@parcel/reporter-cli": "2.16.1",
+        "@parcel/reporter-dev-server": "2.16.1",
+        "@parcel/reporter-tracer": "2.16.1",
+        "@parcel/utils": "2.16.1",
         "chalk": "^4.1.2",
         "commander": "^12.1.0",
         "get-port": "^4.2.0"
@@ -3793,6 +3817,7 @@
       "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -4210,6 +4235,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ttv-lol-pro",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "TTV LOL PRO removes most livestream ads from Twitch.",
   "@parcel/bundler-default": {
     "minBundles": 10000000,

--- a/src/background/handlers/onBeforeVideoWeaverRequest.ts
+++ b/src/background/handlers/onBeforeVideoWeaverRequest.ts
@@ -35,8 +35,8 @@ export default function onBeforeVideoWeaverRequest(
 
     const channelName = findChannelFromVideoWeaverUrl(details.url);
     const isPurpleScreen =
-      textLower.includes("https://example.com") &&
-      textLower.includes("https://help.twitch.tv/");
+      /https?:\/\/([a-z0-9-]+\.)*example\.com/i.test(textLower) &&
+      /https?:\/\/([a-z0-9-]+\.)*twitch\.tv/i.test(textLower);
     const proxy =
       details.proxyInfo && details.proxyInfo.type !== "direct"
         ? getUrlFromProxyInfo(details.proxyInfo)

--- a/src/background/handlers/onResponseStarted.ts
+++ b/src/background/handlers/onResponseStarted.ts
@@ -1,5 +1,6 @@
 import browser, { WebRequest } from "webextension-polyfill";
 import findChannelFromTwitchTvUrl from "../../common/ts/findChannelFromTwitchTvUrl";
+import findChannelFromUsherUrl from "../../common/ts/findChannelFromUsherUrl";
 import findChannelFromVideoWeaverUrl from "../../common/ts/findChannelFromVideoWeaverUrl";
 import getHostFromUrl from "../../common/ts/getHostFromUrl";
 import isChromium from "../../common/ts/isChromium";
@@ -72,58 +73,41 @@ export default async function onResponseStarted(
 
   // Usher requests.
   if (proxiedUsherRequest && usherHostRegex.test(host)) {
-    if (!proxy) return console.log(`❌ Did not proxy ${details.url}`);
-    console.log(`✅ Proxied ${details.url} through ${proxy}`);
+    let channelName = findChannelFromUsherUrl(details.url);
+    if (!channelName) {
+      try {
+        const tab = await browser.tabs.get(details.tabId);
+        channelName = findChannelFromTwitchTvUrl(tab.url);
+      } catch {}
+    }
+    await updateStreamStatus(channelName, proxy, errorMessage);
+
+    if (!proxy) {
+      return console.log(
+        `❌ Did not proxy ${details.url} (${channelName ?? "unknown"})`
+      );
+    }
+    console.log(
+      `✅ Proxied ${details.url} (${channelName ?? "unknown"}) through ${proxy}`
+    );
   }
 
   // Video-weaver requests.
   if (proxiedVideoWeaverRequest && videoWeaverHostRegex.test(host)) {
-    let tabUrl: string | undefined = undefined;
-    try {
-      const tab = await browser.tabs.get(details.tabId);
-      tabUrl = tab.url;
-    } catch {}
-    const channelName =
-      findChannelFromVideoWeaverUrl(details.url) ??
-      findChannelFromTwitchTvUrl(tabUrl);
-    const streamStatus = getStreamStatus(channelName);
-    const stats = streamStatus?.stats ?? { proxied: 0, notProxied: 0 };
+    let channelName = findChannelFromVideoWeaverUrl(details.url);
+    if (!channelName) {
+      try {
+        const tab = await browser.tabs.get(details.tabId);
+        channelName = findChannelFromTwitchTvUrl(tab.url);
+      } catch {}
+    }
+    await updateStreamStatus(channelName, proxy, errorMessage);
 
     if (!proxy) {
-      stats.notProxied++;
-      let reason = errorMessage ?? streamStatus?.reason ?? "";
-      try {
-        const proxySettings = await browser.proxy.settings.get({});
-        switch (proxySettings.levelOfControl) {
-          case "controlled_by_other_extensions":
-            reason = "Proxy settings controlled by other extension";
-            break;
-          case "not_controllable":
-            reason = "Proxy settings not controllable";
-            break;
-        }
-      } catch {}
-      setStreamStatus(channelName, {
-        proxied: false,
-        proxyHost: streamStatus?.proxyHost ? streamStatus.proxyHost : undefined,
-        proxyCountry: streamStatus?.proxyCountry,
-        reason,
-        stats,
-      });
-      console.log(
+      return console.log(
         `❌ Did not proxy ${details.url} (${channelName ?? "unknown"})`
       );
-      return;
     }
-
-    stats.proxied++;
-    setStreamStatus(channelName, {
-      proxied: true,
-      proxyHost: proxy,
-      proxyCountry: streamStatus?.proxyCountry,
-      reason: "",
-      stats,
-    });
     console.log(
       `✅ Proxied ${details.url} (${channelName ?? "unknown"}) through ${proxy}`
     );
@@ -149,10 +133,9 @@ function getProxyFromDetails(
   }
 ): string | null {
   if (isChromium) {
-    const proxies = [
-      ...store.state.optimizedProxies,
-      ...store.state.normalProxies,
-    ];
+    const proxies = Array.from(
+      new Set([...store.state.optimizedProxies, ...store.state.normalProxies])
+    );
     const isDnsError =
       proxies.length !== 0 && store.state.dnsResponses.length === 0;
     if (isDnsError) {
@@ -162,8 +145,8 @@ function getProxyFromDetails(
     }
     const ip = details.ip;
     if (!ip) return null;
-    const dnsResponse = store.state.dnsResponses.find(
-      dnsResponse => dnsResponse.ips.indexOf(ip) !== -1
+    const dnsResponse = store.state.dnsResponses.find(dnsResponse =>
+      dnsResponse.ips.some(responseIp => responseIp === ip)
     );
     if (!dnsResponse) return null;
     const proxyInfoArray = proxies.map(getProxyInfoFromUrl);
@@ -177,4 +160,46 @@ function getProxyFromDetails(
     if (!proxyInfo || proxyInfo.type === "direct") return null;
     return getUrlFromProxyInfo(proxyInfo);
   }
+}
+
+async function updateStreamStatus(
+  channelName: string | null,
+  proxy: string | null,
+  errorMessage: string | null
+) {
+  const streamStatus = getStreamStatus(channelName);
+  const stats = streamStatus?.stats ?? { proxied: 0, notProxied: 0 };
+
+  if (!proxy) {
+    stats.notProxied++;
+    let reason = errorMessage ?? streamStatus?.reason ?? "";
+    try {
+      const proxySettings = await browser.proxy.settings.get({});
+      switch (proxySettings.levelOfControl) {
+        case "controlled_by_other_extensions":
+          reason = "Proxy settings controlled by other extension";
+          break;
+        case "not_controllable":
+          reason = "Proxy settings not controllable";
+          break;
+      }
+    } catch {}
+    setStreamStatus(channelName, {
+      proxied: false,
+      proxyHost: streamStatus?.proxyHost,
+      proxyCountry: streamStatus?.proxyCountry,
+      reason,
+      stats,
+    });
+    return;
+  }
+
+  stats.proxied++;
+  setStreamStatus(channelName, {
+    proxied: true,
+    proxyHost: proxy,
+    proxyCountry: streamStatus?.proxyCountry,
+    reason: "",
+    stats,
+  });
 }

--- a/src/common/ts/updateDnsResponses.ts
+++ b/src/common/ts/updateDnsResponses.ts
@@ -3,75 +3,91 @@ import store from "../../store";
 import type { DnsResponse, DnsResponseJson } from "../../types";
 import { getProxyInfoFromUrl } from "./proxyInfo";
 
+const DNS_API = "https://cloudflare-dns.com/dns-query";
+const MIN_TTL = 300;
+const INFINITE_TTL = -1;
+
 export default async function updateDnsResponses() {
-  const proxies = [
-    ...store.state.optimizedProxies,
-    ...store.state.normalProxies,
-  ];
+  const proxies = Array.from(
+    new Set([...store.state.optimizedProxies, ...store.state.normalProxies])
+  );
   const proxyInfoArray = proxies.map(getProxyInfoFromUrl);
 
   for (const proxyInfo of proxyInfoArray) {
     const { host } = proxyInfo;
 
-    // Check if we already have a valid DNS response for this host.
-    const dnsResponseIndex = store.state.dnsResponses.findIndex(
+    // If we already have a valid DNS response for this host, skip it.
+    const existingIndex = store.state.dnsResponses.findIndex(
       dnsResponse => dnsResponse.host === host
     );
+    const existing =
+      existingIndex !== -1 ? store.state.dnsResponses[existingIndex] : null;
     const isDnsResponseValid =
-      dnsResponseIndex !== -1 &&
-      Date.now() - store.state.dnsResponses[dnsResponseIndex].timestamp <
-        store.state.dnsResponses[dnsResponseIndex].ttl * 1000;
+      existing &&
+      (existing.ttl === INFINITE_TTL ||
+        Date.now() - existing.timestamp < existing.ttl * 1000);
     if (isDnsResponseValid) {
       continue;
     }
 
-    // If the host is an IP address, we don't need to make a DNS request.
+    // If the host is an IP address, use it directly.
     const isIp = Address4.isValid(host) || Address6.isValid(host);
     if (isIp) {
-      const dnsResponse: DnsResponse = {
+      upsertDnsResponse(existingIndex, {
         host,
         ips: [host],
         timestamp: Date.now(),
-        ttl: Infinity,
-      };
-      if (dnsResponseIndex !== -1) {
-        store.state.dnsResponses.splice(dnsResponseIndex, 1, dnsResponse);
-      } else {
-        store.state.dnsResponses.push(dnsResponse);
-      }
+        ttl: INFINITE_TTL,
+      });
       continue;
     }
 
-    // Make the DNS request.
+    // Otherwise, fetch DNS records from the DNS-over-HTTPS API.
     try {
-      const response = await fetch(
-        `https://cloudflare-dns.com/dns-query?name=${encodeURIComponent(host)}`,
-        {
-          headers: {
-            Accept: "application/dns-json",
-          },
-        }
-      );
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}`);
-      }
-      const data: DnsResponseJson = await response.json();
-      if (data.Status !== 0) {
-        throw new Error(`DNS status ${data.Status}`);
-      }
-      const { Answer } = data;
+      const requests = [
+        fetch(`${DNS_API}?name=${encodeURIComponent(host)}&type=A`, {
+          headers: { Accept: "application/dns-json" },
+        }),
+        fetch(`${DNS_API}?name=${encodeURIComponent(host)}&type=AAAA`, {
+          headers: { Accept: "application/dns-json" },
+        }),
+      ];
+      const responses = await Promise.all(requests);
 
-      const dnsResponse: DnsResponse = {
-        host,
-        ips: Answer.map(answer => answer.data),
-        timestamp: Date.now(),
-        ttl: Math.max(Math.max(...Answer.map(answer => answer.TTL)), 300),
-      };
-      if (dnsResponseIndex !== -1) {
-        store.state.dnsResponses.splice(dnsResponseIndex, 1, dnsResponse);
-      } else {
-        store.state.dnsResponses.push(dnsResponse);
+      let ips: string[] = [];
+      let ttl: number | null = null;
+      for (const response of responses) {
+        if (!response.ok) {
+          console.error(
+            `Failed to fetch DNS for ${host}: HTTP ${response.status}`
+          );
+          continue;
+        }
+        const data: DnsResponseJson = await response.json();
+        if (data.Status !== 0) {
+          console.error(`DNS query for ${host} returned status ${data.Status}`);
+          continue;
+        }
+        const { Answer } = data;
+        if (Answer) {
+          ips.push(...Answer.map(answer => answer.data));
+          const answerTtl = Math.min(...Answer.map(answer => answer.TTL));
+          if (ttl == null || answerTtl < ttl) {
+            ttl = answerTtl;
+          }
+        }
       }
+      if (ips.length === 0) {
+        console.error(`No DNS answers found for ${host}`);
+        continue;
+      }
+
+      upsertDnsResponse(existingIndex, {
+        host,
+        ips: Array.from(new Set(ips)), // Remove duplicates
+        timestamp: Date.now(),
+        ttl: ttl ? Math.max(ttl, MIN_TTL) : MIN_TTL, // Enforce minimum TTL
+      });
     } catch (error) {
       console.error(error);
     }
@@ -79,4 +95,17 @@ export default async function updateDnsResponses() {
 
   console.log("🔍 DNS responses updated:");
   console.log(store.state.dnsResponses);
+}
+
+/**
+ * Upsert a DNS response into the store.
+ * @param existingIndex Index of existing DNS response, or -1 if not found.
+ * @param dnsResponse The DNS response to upsert.
+ */
+function upsertDnsResponse(existingIndex: number, dnsResponse: DnsResponse) {
+  if (existingIndex !== -1) {
+    store.state.dnsResponses.splice(existingIndex, 1, dnsResponse);
+  } else {
+    store.state.dnsResponses.push(dnsResponse);
+  }
 }

--- a/src/m3u8-parser.d.ts
+++ b/src/m3u8-parser.d.ts
@@ -4,21 +4,12 @@ declare module "m3u8-parser" {
     allowCache: boolean;
     endList?: boolean;
     mediaSequence?: number;
-    dateRanges: [];
+    dateRanges: { [key: string]: unknown }[];
     discontinuitySequence?: number;
     playlistType?: string;
     custom?: {};
     playlists?: {
-      attributes: {
-        "FRAME-RATE": number;
-        VIDEO: string;
-        CODECS: string;
-        RESOLUTION: {
-          width: number;
-          height: number;
-        };
-        BANDWIDTH: number;
-      };
+      attributes: { [key: string]: unknown };
       uri: string;
       timeline: number;
     }[];

--- a/src/manifest.chromium.json
+++ b/src/manifest.chromium.json
@@ -3,7 +3,7 @@
   "name": "TTV LOL PRO",
   "description": "TTV LOL PRO removes most livestream ads from Twitch.",
   "homepage_url": "https://github.com/younesaassila/ttv-lol-pro",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "background": {
     "service_worker": "background/background.ts",
     "type": "module"
@@ -35,7 +35,6 @@
     "128": "common/images/brand/icon.png"
   },
   "options_ui": {
-    "browser_style": false,
     "open_in_tab": true,
     "page": "options/page.html"
   },

--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -3,7 +3,7 @@
   "name": "TTV LOL PRO",
   "description": "TTV LOL PRO removes most livestream ads from Twitch.",
   "homepage_url": "https://github.com/younesaassila/ttv-lol-pro",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "background": {
     "scripts": ["background/background.ts"],
     "persistent": false

--- a/src/page/getFetch.ts
+++ b/src/page/getFetch.ts
@@ -524,12 +524,14 @@ export function getFetch(pageState: PageState): typeof fetch {
         videoWeaverUrlsToNotProxy.delete(url); // Shouldn't be necessary, but just in case.
         if (isFrontpage || isWhitelisted) videoWeaverUrlsToNotProxy.add(url);
       });
+      const proxyCountryRegex = url.toLowerCase().includes("/api/v2/")
+        ? /"USER-COUNTRY",VALUE="([A-Z]+)"/i
+        : /USER-COUNTRY="([A-Z]+)"/i;
       pageState.sendMessageToContentScript({
         type: MessageType.UsherResponse,
         channel: channelName,
         videoWeaverUrls,
-        proxyCountry:
-          /USER-COUNTRY="([A-Z]+)"/i.exec(responseBody)?.[1] || undefined,
+        proxyCountry: proxyCountryRegex.exec(responseBody)?.[1] || undefined,
       });
       //#endregion
     }
@@ -953,7 +955,8 @@ function parseUsherManifest(manifest: string): Map<string, string> | null {
   }
   return new Map(
     parsedManifest.playlists.map(playlist => [
-      playlist.attributes.VIDEO,
+      (playlist.attributes["STABLE-VARIANT-ID"] ?? // V2 API
+        playlist.attributes["VIDEO"]) as string, // V1 API
       playlist.uri,
     ])
   );
@@ -1016,12 +1019,17 @@ async function updateVideoWeaverReplacementMap(
     // Send replacement Video Weaver URLs to content script.
     const videoWeaverUrls = [...replacementMap.values()];
     if (cachedUsherRequestUrl != null && videoWeaverUrls.length > 0) {
+      const proxyCountryRegex = cachedUsherRequestUrl
+        .toLowerCase()
+        .includes("/api/v2/")
+        ? /"USER-COUNTRY",VALUE="([A-Z]+)"/i
+        : /USER-COUNTRY="([A-Z]+)"/i;
       pageState.sendMessageToContentScript({
         type: MessageType.UsherResponse,
         channel: findChannelFromUsherUrl(cachedUsherRequestUrl),
         videoWeaverUrls,
         proxyCountry:
-          /USER-COUNTRY="([A-Z]+)"/i.exec(newUsherManifest)?.[1] || undefined,
+          proxyCountryRegex.exec(newUsherManifest)?.[1] || undefined,
       });
     }
 


### PR DESCRIPTION
Since [version 2.6.0](https://github.com/younesaassila/ttv-lol-pro/pull/404) requires a bit more work, I'm releasing this version to add support for Twitch's Usher V2 API and fix a few inconveniences.

---

- Stream status statistics now take Usher requests into account. This should help users of the "Unlock Best Quality" experience distinguish between expected vs unexpected behaviors
- Fixed an issue where some requests weren't correctly detected as 'proxied' by the Chromium extension
- Fixed the value of the `isPurpleScreen` property in ad log entries
- Added support for the new Usher V2 Twitch API